### PR TITLE
Fix typo in configure help message and make fails due to  hmp_info_registers() 

### DIFF
--- a/configure
+++ b/configure
@@ -1424,7 +1424,8 @@ Advanced options (experts only):
   --enable-numa            enable libnuma support
   --disable-tcmalloc       disable tcmalloc support
   --enable-tcmalloc        enable tcmalloc support
-  --enable_dift            enable dynamic information flow tracking
+  --enable-dift            enable dynamic information flow tracking
+  --enable-debug-dift      enable debug mode of dynamic information flow tracking
 
 NOTE: The object files are built at the place where configure is launched
 EOF

--- a/monitor.c
+++ b/monitor.c
@@ -1025,7 +1025,7 @@ int monitor_get_cpu_index(void)
     return cpu->cpu_index;
 }
 
-void hmp_info_registers(Monitor *mon, const QDict *qdict)
+static void hmp_info_registers(Monitor *mon, const QDict *qdict)
 {
     CPUState *cpu;
     CPUArchState *env;


### PR DESCRIPTION
1. Add dift-debug-support message in configure help page.
2. Change "--enable_dift" in configure help message to "--enable-dift", which is used in configure argument.
3. Change the function hmp_info_registers() into static to compile correctly, which consistent with other hmp_info_* functions.