### PR TITLE
dift comments, and some dift commands, a new exported mba api

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -134,6 +134,7 @@ obj-$(CONFIG_KVM) += kvm-all.o
 obj-y += memory.o savevm.o cputlb.o
 obj-y += memory_mapping.o
 obj-y += dump.o
+
 LIBS := $(libs_softmmu) $(LIBS)
 
 # xen support
@@ -174,6 +175,9 @@ target-obj-y := $(target-obj-y-save)
 all-obj-y += $(common-obj-y)
 all-obj-y += $(target-obj-y)
 all-obj-$(CONFIG_SOFTMMU) += $(block-obj-y)
+
+# MBA
+all-obj-y += ../ext/dift/dift-commands.o
 
 $(QEMU_PROG_BUILD): config-devices.mak
 

--- a/Makefile.target
+++ b/Makefile.target
@@ -177,7 +177,9 @@ all-obj-y += $(target-obj-y)
 all-obj-$(CONFIG_SOFTMMU) += $(block-obj-y)
 
 # MBA
+ifdef  CONFIG_DIFT
 all-obj-y += ../ext/dift/dift-commands.o
+endif
 
 $(QEMU_PROG_BUILD): config-devices.mak
 

--- a/ext/dift/dift-commands-spec.h
+++ b/ext/dift/dift-commands-spec.h
@@ -1,0 +1,21 @@
+{
+        .name = "contaminate_mem",
+        .args_type  = "addr:l,range:l,contaminate:l",
+        .params     = "addr range contaminate",
+        .help       = "contaminate a byte in memory",
+        .mhandler.cmd = do_memory_contaminate,
+},
+{
+        .name = "show_memory_taint_map",
+        .args_type  = "addr:l,len:l",
+        .params     = "addr len",
+        .help       = "Show memory taint map",
+        .mhandler.cmd = do_show_memory_taint_map,
+},
+{
+        .name = "get_physic_address",
+        .args_type  = "cr3:l,addr:l",
+        .params     = "cr3 addr",
+        .help       = "get the physic address of a given virtual address in memory space(cr3)",
+        .mhandler.cmd = do_get_physic_address,
+},

--- a/ext/dift/dift-commands.c
+++ b/ext/dift/dift-commands.c
@@ -1,0 +1,62 @@
+#include "qemu-common.h"
+#include "monitor/monitor.h"
+#include "include/exec/cpu-common.h"
+#include "exec/cpu-all.h"
+
+#include "ext/dift/dift-commands.h"
+#include "ext/dift/dift.h"
+
+void do_memory_contaminate(Monitor *mon, const QDict *qdict)
+{
+    uint64_t target_addr = qdict_get_int(qdict, "addr");
+    uint64_t target_range = qdict_get_int(qdict, "range");
+    uint64_t contaminate_tag = qdict_get_int(qdict, "contaminate");
+
+    monitor_printf(mon, "Start tainting( addr %ld range %ld contaminate %ld)\n", target_addr, target_range, contaminate_tag);
+    dift_contaminate_memory_or(target_addr, target_range, contaminate_tag & 0xff);
+    monitor_printf(mon, "Taint finish\n");
+}
+
+void do_show_memory_taint_map(struct Monitor *mon, const struct QDict *qdict)
+{
+    uint64_t target_addr = qdict_get_int(qdict, "addr");
+    uint64_t target_length = qdict_get_int(qdict, "len");
+    int i;
+    uint8_t* buf = (uint8_t*)malloc(target_length); 
+    cpu_physical_memory_read(target_addr, buf, target_length);
+    if(buf == NULL){
+        monitor_printf(mon, "Cannot allocate memory for do_show_memory_taint_map()\n");
+        return;
+    }
+
+    monitor_printf(mon, "Taint addr %ld length %ld\n", target_addr, target_length);
+
+    for(i = 0 ; i < target_length ; i++) {
+        monitor_printf( mon, "%02x|%02x, ",
+                buf[i], dift_get_memory_dirty(target_addr + i));
+        if((i & 0xf) == 0xf)
+            monitor_printf(mon, "\n");
+    }
+}
+
+void do_get_physic_address(struct Monitor *mon, const struct QDict *qdict)
+{
+    uint64_t target_cr3		= qdict_get_int(qdict, "cr3");
+    uint64_t target_addr    = qdict_get_int(qdict, "addr");
+    X86CPU *cpu				= X86_CPU(ENV_GET_CPU((CPUArchState*)mba_mon_get_cpu()));
+    hwaddr page             = target_addr & TARGET_PAGE_MASK;
+	
+    //XXX(misterlihao@gmail.com):Only one phase copied. Should be fully copied to resist changes.
+    X86CPU copied_cpu;
+    memcpy(&copied_cpu, cpu, sizeof(copied_cpu));
+    copied_cpu.env.cr[3] = target_cr3;
+    
+    hwaddr phys_page = cpu_get_phys_page_debug((CPUState*)&copied_cpu, page);
+    if (phys_page == -1) {
+        monitor_printf(mon, "Cannot find physic page\n");
+		return;
+    }
+
+    hwaddr phys_addr = phys_page + (target_addr & ~TARGET_PAGE_MASK);
+    monitor_printf(mon, "physic address = %p\n", (void*)phys_addr);
+}

--- a/ext/dift/dift-commands.h
+++ b/ext/dift/dift-commands.h
@@ -1,5 +1,5 @@
-#ifndef __MBA_COMMAND_H_
-#define __MBA_COMMAND_H_
+#ifndef __DIFT_COMMANDS_H__
+#define __DIFT_COMMANDS_H__
 
 struct Monitor;
 struct QDict;

--- a/ext/dift/dift-commands.h
+++ b/ext/dift/dift-commands.h
@@ -1,0 +1,9 @@
+#ifndef __MBA_COMMAND_H_
+#define __MBA_COMMAND_H_
+
+struct Monitor;
+struct QDict;
+void do_memory_contaminate(struct Monitor *mon, const struct QDict *qdict);
+void do_show_memory_taint_map(struct Monitor *mon, const struct QDict *qdict);
+void do_get_physic_address(struct Monitor *mon, const struct QDict *qdict);
+#endif

--- a/ext/dift/dift.h
+++ b/ext/dift/dift.h
@@ -347,9 +347,6 @@ extern uint8_t* rt_enqueue_one_rec;
 extern uint8_t* rt_enqueue_raddr;
 extern uint8_t* rt_enqueue_waddr;
 
-/// FIXME(misterlihao@gmail.com): This should be removed.
-extern void dift_enqueue(uint32_t);
-
 /// Inform dift system and then block(spinning) until
 /// dift system declares to accept more IFcodes.
 /// Current Called before translating every code blocks.

--- a/ext/dift/dift.h
+++ b/ext/dift/dift.h
@@ -347,7 +347,16 @@ extern uint8_t* rt_enqueue_one_rec;
 extern uint8_t* rt_enqueue_raddr;
 extern uint8_t* rt_enqueue_waddr;
 
+/// FIXME(misterlihao@gmail.com): This should be removed.
 extern void dift_enqueue(uint32_t);
+
+/// Inform dift system and then block(spinning) until
+/// dift system declares to accept more IFcodes.
+/// Current Called before translating every code blocks.
+///
+/// no parameter
+///
+/// no return value
 extern void dift_sync(void);
 
 ///
@@ -365,34 +374,96 @@ extern uint32_t dift_code_loc;
 extern uint32_t dift_code_off;
 extern int label_or_helper_appeared;
 
+/// Initializes dift function.
+/// Currently called in pc_init1() (in Pc_piix.c)
+/// 
+/// No parameter
+/// 
+/// Returns 1 if create dift thread successfully,0 otherwise.
 extern int dift_start(void);
 
-
+/// Pushes a "struct dift_record", or additional information(like addr) into the queue.
+/// 
+/// \param data_in  struct dift_record data_in, which is going to be enqueued
+/// 
+/// No return value
 extern void    dift_rec_enqueue( uint64_t data_in );
-extern uint8_t dift_rec_case_nb(uint8_t, uint8_t, uint8_t, uint8_t);
+
+/// Get the case number corresponding to specified arguments.
+/// The case numbers are also the indices of array "dispatch",
+/// which stores addresses for the IFcode handlers.
+/// The case number is correspond to the field .case_nb of struct dift_record.
+/// 
+/// \param dst_type	destination type 
+/// \param src_type	source type
+/// \param ot		operand type(8,16,32,etc)
+/// \param effect   effect type
+///
+/// No return value
+extern uint8_t dift_rec_case_nb(uint8_t dst_type, uint8_t src_type, uint8_t ot, uint8_t effect);
 
 extern int dift_is_tag_valid( const CONTAMINATION_RECORD );
 
-extern int dift_contaminate_memory_or(uint64_t, uint64_t, CONTAMINATION_RECORD);
-extern int dift_contaminate_memory_and(uint64_t, uint64_t, CONTAMINATION_RECORD);
-extern int dift_contaminate_disk_or(uint64_t, uint64_t, CONTAMINATION_RECORD);
-extern int dift_contaminate_disk_and(uint64_t, uint64_t, CONTAMINATION_RECORD);
+/// Set the contaminate record to the result of or operation with tag.
+/// 
+/// \param addr     The starting memory address to be set
+/// \param len      The length(in bytes) to be set
+/// \param tag      The contaminate value
+/// 
+/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
+extern int dift_contaminate_memory_or(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
 
+/// Set the contaminate record to the result of and operation with tag.
+/// 
+/// \param addr     The starting memory address to be set
+/// \param len      The length(in bytes) to be set
+/// \param tag      The contaminate value
+/// 
+/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
+extern int dift_contaminate_memory_and(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
 
-///
+/// Set the contaminate record to the result of or operation with tag.
+/// 
+/// \param addr     The starting disk address to be set
+/// \param len      The length(in bytes) to be set
+/// \param tag      The contaminate value
+/// 
+/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
+extern int dift_contaminate_disk_or(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
+
+/// Set the contaminate record to the result of and operation with tag.
+/// 
+/// \param addr     The starting disk address to be set
+/// \param len      The length(in bytes) to be set
+/// \param tag      The contaminate value
+/// 
+/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
+extern int dift_contaminate_disk_and(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
+
 /// Get the contamination status of a phsical memory byte.
 /// The most significant bit is used for marking whether a code block contains tainted code.
-///
+/// 
+/// \param offset   The address of the byte in memory to be checked
+/// 
+/// Returns CONTAMINATION_RECORD type.
 extern CONTAMINATION_RECORD dift_get_memory_dirty(uint64_t offset);
+
+/// Get the contamination status of a disk byte.
+/// The most significant bit is used for marking whether a code block contains tainted code.
+/// 
+/// \param hdaddr   The address of the byte in disk to be checked
+/// 
+/// Returns CONTAMINATION_RECORD type.
 extern CONTAMINATION_RECORD dift_get_disk_dirty(uint64_t hdaddr);
 
-///
 /// Flush the record queue if needed.
 ///
 /// \param cnt   Number of sets of records that have already been enqueued. Each set of records
 ///              may be enqueued by several enqueue() call.
-///
+/// FIXME(misterlihao): Definition not found.
 void record_queue_flush(size_t cnt);
+
+/// FIXME(misterlihao): Definition not found.
 extern void clear_memory(uint64_t, uint64_t);
 
 

--- a/include/monitor/monitor.h
+++ b/include/monitor/monitor.h
@@ -42,6 +42,11 @@ void monitor_printf(Monitor *mon, const char *fmt, ...) GCC_FMT_ATTR(2, 3);
 void monitor_flush(Monitor *mon);
 int monitor_set_cpu(int cpu_index);
 int monitor_get_cpu_index(void);
+/* dsns extension--- */
+/// Returns CPUArchState (not determined here) pointer.
+void *mba_mon_get_cpu(void);
+/* ---dsns extension */
+
 
 typedef void (MonitorCompletion)(void *opaque, QObject *ret_data);
 

--- a/monitor.c
+++ b/monitor.c
@@ -81,6 +81,12 @@
 #endif
 #include "hw/lm32/lm32_pic.h"
 
+#if defined(CONFIG_DIFT)
+#include "ext/dift/dift-commands.h"
+#endif
+void do_get_physic_address(struct Monitor *mon, const struct QDict *qdict);
+
+
 //#define DEBUG
 //#define DEBUG_COMPLETION
 
@@ -1017,6 +1023,11 @@ static CPUArchState *mon_get_cpu(void)
     }
     cpu_synchronize_state(cur_mon->mon_cpu);
     return cur_mon->mon_cpu->env_ptr;
+}
+
+void *mba_mon_get_cpu(void)
+{
+    return mon_get_cpu();
 }
 
 int monitor_get_cpu_index(void)
@@ -2943,6 +2954,16 @@ static mon_cmd_t info_cmds[] = {
 /* mon_cmds and info_cmds would be sorted at runtime */
 static mon_cmd_t mon_cmds[] = {
 #include "hmp-commands.h"
+#if defined(CONFIG_DIFT)
+#include "ext/dift/dift-commands-spec.h"
+#endif
+{
+        .name = "get_physic_address",
+        .args_type  = "cr3:l,addr:l",
+        .params     = "cr3 addr",
+        .help       = "get the physic address of a given virtual address in memory space(cr3)",
+        .mhandler.cmd = do_get_physic_address,
+},
     { NULL, NULL, },
 };
 

--- a/monitor.c
+++ b/monitor.c
@@ -84,7 +84,6 @@
 #if defined(CONFIG_DIFT)
 #include "ext/dift/dift-commands.h"
 #endif
-void do_get_physic_address(struct Monitor *mon, const struct QDict *qdict);
 
 
 //#define DEBUG
@@ -2957,13 +2956,6 @@ static mon_cmd_t mon_cmds[] = {
 #if defined(CONFIG_DIFT)
 #include "ext/dift/dift-commands-spec.h"
 #endif
-{
-        .name = "get_physic_address",
-        .args_type  = "cr3:l,addr:l",
-        .params     = "cr3 addr",
-        .help       = "get the physic address of a given virtual address in memory space(cr3)",
-        .mhandler.cmd = do_get_physic_address,
-},
     { NULL, NULL, },
 };
 


### PR DESCRIPTION
- Add comments of dift functions, make prototype parameters named.
- dift_enqueue is removed.

- some commands are added.
contaminate_mem, show_memory_taint_map, get_physic_address

- one new api exported:
mba_mon_get_cpu