### PR TITLE
introduce Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 language: c
-python:
-  - "2.4"
+
+sudo: required
 compiler:
   - gcc
-  - clang
-notifications:
-  irc:
-    channels:
-      - "irc.oftc.net#qemu"
-    on_success: change
-    on_failure: always
 env:
   global:
+    - TARGETS=x86_64-softmmu
     - TEST_CMD=""
     - EXTRA_CONFIG=""
     # Development packages, EXTRA_PKGS saved for additional builds
@@ -19,85 +13,32 @@ env:
     - NET_PKGS="libseccomp-dev libgnutls-dev libssh2-1-dev  libspice-server-dev libspice-protocol-dev libnss3-dev"
     - GUI_PKGS="libgtk-3-dev libvte-2.90-dev libsdl1.2-dev libpng12-dev libpixman-1-dev"
     - EXTRA_PKGS=""
-  matrix:
-    # Group major targets together with their linux-user counterparts
-    - TARGETS=alpha-softmmu,alpha-linux-user
-    - TARGETS=arm-softmmu,arm-linux-user,armeb-linux-user,aarch64-softmmu,aarch64-linux-user
-    - TARGETS=cris-softmmu,cris-linux-user
-    - TARGETS=i386-softmmu,i386-linux-user,x86_64-softmmu,x86_64-linux-user
-    - TARGETS=m68k-softmmu,m68k-linux-user
-    - TARGETS=microblaze-softmmu,microblazeel-softmmu,microblaze-linux-user,microblazeel-linux-user
-    - TARGETS=mips-softmmu,mips64-softmmu,mips64el-softmmu,mipsel-softmmu
-    - TARGETS=mips-linux-user,mips64-linux-user,mips64el-linux-user,mipsel-linux-user,mipsn32-linux-user,mipsn32el-linux-user
-    - TARGETS=or32-softmmu,or32-linux-user
-    - TARGETS=ppc-softmmu,ppc64-softmmu,ppcemb-softmmu,ppc-linux-user,ppc64-linux-user,ppc64abi32-linux-user,ppc64le-linux-user
-    - TARGETS=s390x-softmmu,s390x-linux-user
-    - TARGETS=sh4-softmmu,sh4eb-softmmu,sh4-linux-user sh4eb-linux-user
-    - TARGETS=sparc-softmmu,sparc64-softmmu,sparc-linux-user,sparc32plus-linux-user,sparc64-linux-user
-    - TARGETS=unicore32-softmmu,unicore32-linux-user
-    # Group remaining softmmu only targets into one build
-    - TARGETS=lm32-softmmu,moxie-softmmu,tricore-softmmu,xtensa-softmmu,xtensaeb-softmmu
 git:
-  # we want to do this ourselves
   submodules: false
 before_install:
+  - grep MemTotal /proc/meminfo
+  - pwd
+  - df -h
+  - if [ "$NEED_IMAGE" == "Y" ]; then
+    perl gdown.pl/gdown.pl "https://docs.google.com/uc?id=0B3tO_KfVdaBJV1Q5TG5PZjY0RDg&export=download" win10.qcow2;
+    fi
   - wget -O - http://people.linaro.org/~alex.bennee/qemu-submodule-git-seed.tar.xz | tar -xvJ
   - git submodule update --init --recursive
   - sudo apt-get update -qq
   - sudo apt-get install -qq ${CORE_PKGS} ${NET_PKGS} ${GUI_PKGS} ${EXTRA_PKGS}
+  - sudo ldconfig -v
+  - ls /usr/lib
+  - git clone https://github.com/google/googletest.git
+  - g++ -isystem googletest/googletest/include/ -Igoogletest/googletest -pthread -c googletest/googletest/src/gtest-all.cc -DGTEST_CREATE_SHARED_LIBRARY=1 -fPIC -shared -o libgtest.so
+  - sudo mv libgtest.so /usr/lib/
+  - sudo mv googletest/googletest/include/* /usr/include/
 before_script:
-  - ./configure --target-list=${TARGETS} --enable-debug-tcg ${EXTRA_CONFIG}
+  - ./configure --target-list=${TARGETS} ${EXTRA_CONFIG}
 script:
-  - make -j2 && ${TEST_CMD}
-matrix:
-  # We manually include a number of additional build for non-standard bits
+  - make -j4 && sh -c "${TEST_CMD}"
+matrix: # define more builds here
   include:
-    # Make check target (we only do this once)
-    - env:
-        - TARGETS=alpha-softmmu,arm-softmmu,aarch64-softmmu,cris-softmmu,
-                  i386-softmmu,x86_64-softmmu,m68k-softmmu,microblaze-softmmu,
-                  microblazeel-softmmu,mips-softmmu,mips64-softmmu,
-                  mips64el-softmmu,mipsel-softmmu,or32-softmmu,ppc-softmmu,
-                  ppc64-softmmu,ppcemb-softmmu,s390x-softmmu,sh4-softmmu,
-                  sh4eb-softmmu,sparc-softmmu,sparc64-softmmu,
-                  unicore32-softmmu,unicore32-linux-user,
-                  lm32-softmmu,moxie-softmmu,tricore-softmmu,xtensa-softmmu,
-                  xtensaeb-softmmu
-          TEST_CMD="make check"
-      compiler: gcc
-    # Debug related options
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-debug"
-      compiler: gcc
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-debug --enable-tcg-interpreter"
-      compiler: gcc
-    # All the extra -dev packages
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_PKGS="libaio-dev libcap-ng-dev libattr1-dev libbrlapi-dev uuid-dev libusb-1.0.0-dev"
-      compiler: gcc
-    # Currently configure doesn't force --disable-pie
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-gprof --enable-gcov --disable-pie"
-      compiler: gcc
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_PKGS="sparse"
-           EXTRA_CONFIG="--enable-sparse"
-      compiler: gcc
-    # All the trace backends (apart from dtrace)
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-trace-backends=stderr"
-      compiler: gcc
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-trace-backends=simple"
-      compiler: gcc
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-trace-backends=ftrace"
-      compiler: gcc
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-          EXTRA_PKGS="liblttng-ust-dev liburcu-dev"
-          EXTRA_CONFIG="--enable-trace-backends=ust"
-      compiler: gcc
-    - env: TARGETS=i386-softmmu,x86_64-softmmu
-           EXTRA_CONFIG="--enable-modules"
+    # enable dift, and corresponding unit tests
+    - env: EXTRA_CONFIG="--enable-dift"
+           TEST_CMD="make --directory=ext/dift/test && ext/dift/test/gtest_dift"
       compiler: gcc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-Malware Behavior Analyzer, MBA
+Malware Behavior Analyzer, MBA [![Build Status](https://travis-ci.org/misterlihao/MBA.svg?branch=temp-demo-travis-ci)](https://travis-ci.org/misterlihao/MBA)
 
 MBA is a QEMU-based, sandbox system dedicated to malware analysis for Windows x64
 Currently, MBA supports the following features:

--- a/gdown.pl/LICENSE
+++ b/gdown.pl/LICENSE
@@ -1,0 +1,6 @@
+gdown.pl
+
+by circulosmeos 04-2014.
+
+Released under GPL v3
+http://www.gnu.org/copyleft/gpl.html

--- a/gdown.pl/README.md
+++ b/gdown.pl/README.md
@@ -1,0 +1,20 @@
+gdown.pl
+========
+
+Google Drive direct download of big files
+
+Usage
+=====
+
+$ ./gdown.pl 'gdrive file url' ['desired file name']
+
+License
+=======
+
+Distributed [under GPL 3](http://www.gnu.org/licenses/gpl-3.0.html)
+
+Contact
+=======
+
+by [circulosmeos](http://circulosmeos.wordpress.com/2014/04/12/google-drive-direct-download-of-big-files) 04-2014.
+

--- a/gdown.pl/gdown.pl
+++ b/gdown.pl/gdown.pl
@@ -1,0 +1,62 @@
+#!/usr/local/bin/perl
+#
+# Google Drive direct download of big files
+# ./gdown.pl 'gdrive file url' ['desired file name']
+#
+# v1.0 by circulosmeos 04-2014.
+# http://circulosmeos.wordpress.com/2014/04/12/google-drive-direct-download-of-big-files
+# Distributed under GPL 3 (http://www.gnu.org/licenses/gpl-3.0.html)
+#
+use strict;
+
+my $TEMP='/tmp';
+my $COMMAND;
+my $confirm;
+my $check;
+sub execute_command();
+
+my $URL=shift;
+die "\n./gdown.pl 'gdrive file url' [desired file name]\n\n" if $URL eq '';
+my $FILENAME=shift;
+$FILENAME='gdown' if $FILENAME eq '';
+
+execute_command();
+
+while (-s $FILENAME < 100000) { # only if the file isn't the download yet
+    open fFILENAME, '<', $FILENAME;
+    $check=0;
+    foreach (<fFILENAME>) {
+        if (/href="(\/uc\?export=download[^"]+)/) {
+            $URL='https://docs.google.com'.$1;
+            $URL=~s/&amp;/&/g;
+            $confirm='';
+            $check=1;
+            last;
+        }
+        if (/confirm=([^;&]+)/) {
+            $confirm=$1;
+            $check=1;
+            last;
+        }
+        if (/"downloadUrl":"([^"]+)/) {
+            $URL=$1;
+            $URL=~s/\\u003d/=/g;
+            $URL=~s/\\u0026/&/g;
+            $confirm='';
+            $check=1;
+            last;
+        }
+    }
+    close fFILENAME;
+    die "Couldn't download the file :-(\n" if ($check==0);
+    $URL=~s/confirm=([^;&]+)/confirm=$confirm/ if $confirm ne '';
+
+    execute_command();
+}
+
+sub execute_command() {
+    $COMMAND="wget --load-cookie $TEMP/cookie.txt --save-cookie $TEMP/cookie.txt \"$URL\"";
+    $COMMAND.=" -O \"$FILENAME\"" if $FILENAME ne '';
+    `$COMMAND`;
+    return 1;
+}

--- a/libcacard/libcacard.pc.in
+++ b/libcacard/libcacard.pc.in
@@ -1,0 +1,13 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=@LIBDIR@
+includedir=@INCLUDEDIR@
+
+Name: cacard
+Description: CA Card library
+Version: @VERSION@
+
+Requires:  nss
+Libs: -L${libdir} -lcacard
+Libs.private:
+Cflags: -I${includedir}


### PR DESCRIPTION
- Trim .travis.yml to fit needs of MBA
  - remove builds of clang compiler
  - remove builds for all platforms except x86_64
  - add build for dift testing
- Rename README to README.md to enable markdown rendering
- Add build status icon to README (also a hyperlink to travis page)
- Add gdown.pl for downloading files from google drive
- Add missing libcacard/libcacard.pc.in