### PR TITLE
Add out-of-box hooking (obhook) extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,7 @@ matrix: # define more builds here
     - env: EXTRA_CONFIG="--enable-dift"
            TEST_CMD="make dift -C ext/ -f Makefile.test && ext/dift/test/bin/test_dift"
       compiler: gcc
+    # enable & run obhook unit test
+    - env: EXTRA_CONFIG="--enable-obhook"
+           TEST_CMD="make obhook -C ext -f Makefile.test && ext/obhook/test/bin/test_obhook"
+      compiler: gcc

--- a/Makefile.target
+++ b/Makefile.target
@@ -197,6 +197,10 @@ all-obj-y += ../ext/tsk/tsk-commands.o
 ../ext/tsk/tsk-commands.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit 
 endif
 
+ifdef CONFIG_OBHOOK
+all-obj-y += ../ext/obhook/obhook.o
+endif
+
 
 $(QEMU_PROG_BUILD): config-devices.mak
 

--- a/Makefile.target
+++ b/Makefile.target
@@ -199,6 +199,7 @@ endif
 
 ifdef CONFIG_OBHOOK
 all-obj-y += ../ext/obhook/obhook.o
+all-obj-y += ../ext/obhook/obhook-commands.o
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The following features are supported:
          > execute a command in the guest w/wo return output expected
          > import/export a file into/from the guest
 
+    5. Out-of-Box Hooking (OBHook)
+       The obhook extension provides the VM-based hook against the guest OS.
+       This features allows MBA to intercept the event-of-interest of the guest.
+       Note that the obhook is purely implemented beneath the guest OS, namely
+       the hypervisor (QEMU). Thereby, not a code snippets is required to be
+       inserted to the guest, and thus prevent the interference of malware.
+
 More features are under development.
 
 # Quick Start

--- a/configure
+++ b/configure
@@ -343,6 +343,7 @@ dift_debug="no"
 agent="no"
 memfrs="no"
 tsk="no"
+obhook="no"
 #########################
 
 # parse CC options first
@@ -1157,12 +1158,15 @@ for opt do
   ;;
   --enable-tsk) tsk="yes"
   ;;
+  --enable-obhook) obhook="yes"
+  ;;
   --enable-mba-all)
     dift="yes"
     dift_debug="yes"
     agent="yes"
     memfrs="yes"
     tsk="yes"
+    obhook="yes"
   ;;
   #########################
   *)
@@ -1440,11 +1444,13 @@ Advanced options (experts only):
   --enable-numa            enable libnuma support
   --disable-tcmalloc       disable tcmalloc support
   --enable-tcmalloc        enable tcmalloc support
-  --enable-dift            enable dynamic information flow tracking
+  --enable-dift            enable decoupled/dynamic information flow tracking
   --enable-debug-dift      enable debug mode of dynamic information flow tracking
   --enable-agent           enable Windows in-VM agent
   --enable-tsk             enable sleuth kit disk forensics sopport
   --enable-memfrs          enable Virtual Machine Memory Introspection for Windows
+  --enable-obhook          enable Out-of-Box hooking for Windows 10 x64
+  --enable-mba-all         enable all of the MBA features
 
 NOTE: The object files are built at the place where configure is launched
 EOF
@@ -4513,6 +4519,7 @@ echo "dift debug support          $dift_debug"
 echo "Windows in-VM agent support $agent"
 echo "memory forensics support    $memfrs"
 echo "disk forensics(tsk) support $tsk"
+echo "Out-of-Box hook support     $obhook"
 #########################
 
 if test "$sdl_too_old" = "yes"; then
@@ -5407,9 +5414,15 @@ if test "$memfrs" = "yes"; then
   echo "CONFIG_MEMFRS=y" >> $config_host_mak
   echo "CONFIG_MEMFRS=y" >> $config_target_mak
 fi
+
 if test "$tsk" = "yes"; then
   echo "CONFIG_TSK=y" >> $config_host_mak
   echo "CONFIG_TSK=y" >> $config_target_mak
+fi
+
+if test "$obhook" = "yes"; then
+  echo "CONFIG_OBHOOK=y" >> $config_host_mak
+  echo "CONFIG_OBHOOK=y" >> $config_target_mak
 fi
 #########################
 

--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -32,6 +32,10 @@
 #include "ext/dift/dift.h"
 #endif
 
+#if defined(CONFIG_OBHOOK)
+#include "ext/obhook/obhook.h"
+#endif
+
 /* -icount align implementation. */
 
 typedef struct SyncClocks {
@@ -490,6 +494,17 @@ int cpu_exec(CPUArchState *env)
                 if( dift_code_top + 10000 > CONFIG_MAX_TB_ESTI )
                     tb_flush( env );
 #endif
+
+#if defined(CONFIG_OBHOOK)
+                // if any pending hooks which are newly registered,
+                // the translated code block should be flushed
+                if( obhook_pending_hooks ) {
+                    tb_flush( env );
+                    obhook_pending_hooks = false;
+                }
+
+#endif
+
                 spin_lock(&tcg_ctx.tb_ctx.tb_lock);
                 have_tb_lock = true;
                 tb = tb_find_fast(env);

--- a/ext/Makefile.test
+++ b/ext/Makefile.test
@@ -28,6 +28,10 @@ agent: $(GTEST_LIB)
 	cd agent/test && \
 	make GTEST_DIR=$(GTEST_DIR) GMOCK_DIR=$(GMOCK_DIR) GTEST_LIB=$(GTEST_LIB)
 
+obhook: $(GTEST_LIB)
+	cd obhook/test && \
+	make GTEST_DIR=$(GTEST_DIR) GMOCK_DIR=$(GMOCK_DIR) GTEST_LIB=$(GTEST_LIB)
+
 $(GTEST_LIB):
 	rm -rf $(GTEST_ROOT)
 	git clone https://github.com/google/googletest.git $(GTEST_ROOT)
@@ -46,3 +50,4 @@ clean:
 	cd tsk/test && make clean
 	cd memfrs/test && make clean
 	cd agent/test && make clean
+	cd obhook/test && make clean

--- a/ext/README
+++ b/ext/README
@@ -5,3 +5,4 @@ Note that each directory must containt the source and the test/ directory for th
     2. TSK      The disk forensics based on customized The Sleuth Kit
     3. MEMFRS   The memory forensics for Windows 10 x64 guest OS
     4. AGENT    The in-VM agent for Windows 10 x64 guest OS
+    5. OBHOOK   The Out-of-Box Hooking, a VM-based whole-system hook against guest OS

--- a/ext/obhook/obhook-commands-spec.h
+++ b/ext/obhook/obhook-commands-spec.h
@@ -1,0 +1,46 @@
+/*
+ *  MBA Out-of-Box Hooking QEMU command specification 
+ *
+ *  Copyright (c)   2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+{
+        .name      = "list_obhook",
+        .args_type = "",
+        .params    = "",
+        .help      = "list all registered out-of-box hooks",
+        .mhandler.cmd = do_list_obhook,
+},
+{
+        .name      = "delete_obhook",
+        .args_type = "obhook_d:i",
+        .params    = "obhook_descriptor",
+        .help      = "delete an out-of-box hook specified by the descriptor number",
+        .mhandler.cmd = do_delete_obhook,
+},
+{
+        .name      = "enable_obhook",
+        .args_type = "obhook_d:i",
+        .params    = "obhook_descriptor",
+        .help      = "enable an out-of-box hook specified by the descriptor number",
+        .mhandler.cmd = do_enable_obhook,
+},
+{
+        .name      = "disable_obhook",
+        .args_type = "obhook_d:i",
+        .params    = "obhook_descriptor",
+        .help      = "disable an out-of-box hook specified by the descriptor number",
+        .mhandler.cmd = do_disable_obhook,
+},

--- a/ext/obhook/obhook-commands.c
+++ b/ext/obhook/obhook-commands.c
@@ -1,7 +1,7 @@
 /*
  *  HMP command implementation of the MBA out-of-box hook
  *
- *  Copyright (c)   2012 Chiawei Wang
+ *  Copyright (c)   2016 Chiawei Wang
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/ext/obhook/obhook-commands.c
+++ b/ext/obhook/obhook-commands.c
@@ -1,0 +1,90 @@
+/*
+ *  HMP command implementation of the MBA out-of-box hook
+ *
+ *  Copyright (c)   2012 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#include "qemu-common.h"
+#include "monitor/monitor.h"
+#include "qmp-commands.h"
+#include "obhook-commands.h"
+#include "obhook.h"
+
+void do_list_obhook( Monitor* mon, const QDict* qdict ) {
+
+    obhk_ht_record* ht_rec;
+    obhk_ht_record* ht_tmp;
+
+    obhk_ht_record* ht_proc_rec;
+    obhk_ht_record* ht_proc_tmp;
+
+    obhk_cb_record* cb_rec;
+
+    HASH_ITER( hh, obhk_ctx->hook_tbl, ht_rec, ht_tmp ) {
+
+        if( ht_rec == NULL )
+            break;
+
+        if( ht_rec->cr3 == 0 )
+            monitor_printf( mon, "----- Universal\n" );
+        else
+            monitor_printf( mon, "----- Process %016lx\n", ht_rec->cr3 );
+
+        HASH_ITER( hh, ht_rec->proc_obhk_tbl, ht_proc_rec, ht_proc_tmp ) {
+
+            if( ht_proc_rec == NULL )
+                break;
+
+            monitor_printf( mon, "    %016lx: \n", ht_proc_rec->addr );
+            LL_FOREACH( ht_proc_rec->cb_list, cb_rec ) {
+                monitor_printf( mon, "\t%5d, %10s, %16s\n", 
+                            cb_rec->uid,
+                            (cb_rec->enabled)? "enabled" : "disabled",
+                            cb_rec->label );
+            }
+        }
+    }
+    printf( "\n" );
+}
+
+void do_delete_obhook( Monitor* mon, const QDict* qdict ) {
+
+    int obhook_d = qdict_get_int( qdict, "obhook_d" );
+
+    if( obhook_delete(obhook_d) != 0 ) 
+        monitor_printf( mon, "fail to delete the hook\n" );
+    else
+        monitor_printf( mon, "success\n" );
+}
+
+void do_enable_obhook( Monitor* mon, const QDict* qdict ) {
+    
+    int obhook_d = qdict_get_int( qdict, "obhook_d" );
+
+    if( obhook_enable(obhook_d) != 0 ) 
+        monitor_printf( mon, "fail to enable the hook\n" );
+    else
+        monitor_printf( mon, "success\n" );
+}
+
+void do_disable_obhook( Monitor* mon, const QDict* qdict ) {
+    
+    int obhook_d = qdict_get_int( qdict, "obhook_d" );
+
+    if( obhook_disable(obhook_d) != 0 ) 
+        monitor_printf( mon, "fail to disable the hook\n" );
+    else
+        monitor_printf( mon, "success\n" );
+}

--- a/ext/obhook/obhook-commands.h
+++ b/ext/obhook/obhook-commands.h
@@ -1,0 +1,30 @@
+/*
+ *  HMP command header of the MBA out-of-box hook
+ *
+ *  Copyright (c)   2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef __OBHOOK_COMMANDS_H__
+#define __OBHOOK_COMMANDS_H__
+
+struct Monitor;
+struct QDict;
+
+void do_list_obhook( Monitor* mon, const QDict* qdict );
+void do_delete_obhook( Monitor* mon, const QDict* qdict );
+void do_enable_obhook( Monitor* mon, const QDict* qdict );
+void do_disable_obhook( Monitor* mon, const QDict* qdict );
+
+#endif

--- a/ext/obhook/obhook.c
+++ b/ext/obhook/obhook.c
@@ -1,0 +1,20 @@
+/*
+ *  Out-of-Box Hook implementation
+ *
+ *  Copyright (c)   2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "obhook.h"

--- a/ext/obhook/obhook.c
+++ b/ext/obhook/obhook.c
@@ -17,4 +17,299 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "uthash.h"
+#include "utlist.h"
 #include "obhook.h"
+
+#define MASK_KERN_ADDR 0xffff000000000000
+
+// globally accessible error number of obhook
+OBHOOK_ERRNO obhook_errno;
+
+bool obhook_pending_hooks;
+
+struct obhk_ht_record;
+struct obhk_cb_record;
+
+/// To keep the simplicity of implementation,
+/// obkh_ht_recrod as the hash table key is designed to support
+/// both per-process and universal hooks
+struct obhk_ht_record {
+
+    target_ulong addr;
+
+    // cr3 = 0 indicates an universal hook
+    target_ulong cr3;
+
+    // used for per-process hook
+    struct obhk_ht_record* proc_obhk_tbl;
+
+    // callback routines registered
+    struct obhk_cb_record* cb_list;
+
+    // handle for hash table
+    UT_hash_handle hh;
+};
+typedef struct obhk_ht_record obhk_ht_record;
+
+struct obhk_cb_record {
+
+    // a reverse-pointer to the hash table record
+    struct obhk_ht_record* ht_rec;
+
+    // unique identifier for each hook
+    uint16_t uid;
+
+    bool enabled;
+    bool universal;
+
+    // user-friendly label string
+    char label[MAX_SZ_OBHOOK_LABEL];
+
+    void* (*cb_func) (void*);
+
+    struct obhk_cb_record* next;
+};
+typedef struct obhk_cb_record obhk_cb_record; 
+
+struct obhook_context {
+
+    // 2-layers lookup hash table for out-of-box hook
+    //   The 1-layer is indexed by process CR3
+    //   The 2-layer is indexed by address where the hook implanted at
+    //
+    // Note that the hash record with CR3=0 indicates 
+    // the universal hooks, which are trigger regardless 
+    // of processes and the address is in kernel space.
+    obhk_ht_record* hook_tbl;
+
+    // the fast index table for queries to registered hook
+    obhk_cb_record* index_tbl[MAX_NM_OBHOOK];
+};
+typedef struct obhook_context obhook_context;
+
+// file-global context for out-of-box hooking
+static obhook_context obhk_ctx[1];
+
+/// Private function
+/// These function should be invoked only in the scope of this file
+
+/// Search available slot in the index table
+/// Return index number as the uid for a new obhook, -1 if no more obhook space
+static int get_obhook_uid( void ) {
+
+    int i;
+    for( i = 0; i < MAX_NM_OBHOOK; ++i )
+        if( obhk_ctx->index_tbl[i] == NULL )
+            break;
+
+    return (i == MAX_NM_OBHOOK)? -1 : i;
+}
+
+/// Check if the given address is in kernel space
+/// NOTE that the check is based on the memory layout of Windows 10 x64 
+static inline bool is_kern_addr( target_ulong addr ) {
+    return ((addr & MASK_KERN_ADDR) == MASK_KERN_ADDR);
+}
+
+static int toggle_obhk( int obhook_d, bool enabled ) {
+
+    if( obhk_ctx->index_tbl[obhook_d] == NULL ) {
+        obhook_errno = OBHOOK_ERR_INVALID_DESCRIPTOR;
+        return -1;
+    }
+
+    obhk_ctx->index_tbl[obhook_d]->enabled = enabled;
+
+    return 0;
+}
+
+static int add_obhk_internal( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void*) ) {
+
+    obhk_ht_record* ht_rec;
+    obhk_ht_record* ht_proc_rec;
+    obhk_cb_record* cb_rec;
+ 
+    int new_uid;
+
+    // check if there are avaible space for the new hook
+    // if yes, take the uid first
+    new_uid = get_obhook_uid();
+    if( new_uid == -1 ) {
+        obhook_errno = OBHOOK_ERR_FULL_HOOK;
+        goto obhk_add_fail;
+    }
+
+    // if cr3 is 0, indicating universal hook,
+    // check if the given address is in kernel space
+    if( cr3 == 0 && !is_kern_addr(addr) ) {
+        obhook_errno = OBHOOK_ERR_INVALID_ADDR;
+        goto obhk_add_fail;
+    }
+
+    // check label 
+    if( label != NULL && strlen(label) >= MAX_SZ_OBHOOK_LABEL ) {
+        obhook_errno = OBHOOK_ERR_INVALID_LABEL;
+        goto obhk_add_fail;
+    }
+
+    // check callback pointer
+    if( cb == NULL ) {
+        obhook_errno = OBHOOK_ERR_INVALID_CALLBACK;
+        goto obhk_add_fail;
+    }
+
+    // check if any hook has been implanted at the process
+    // if not, add the 1-layer hash table record
+    HASH_FIND( hh, obhk_ctx->hook_tbl, &cr3, sizeof(target_ulong), ht_rec );
+    if( ht_rec == NULL ) {
+
+        // create the 1-layer hash table, indexed by CR3
+        ht_rec = (obhk_ht_record*)calloc( 1, sizeof(obhk_ht_record) );
+        if( ht_rec == NULL ) {
+            obhook_errno = OBHOOK_ERR_FAIL;
+            goto obhk_add_fail;
+        }
+
+        // setup CR3 index
+        ht_rec->cr3 = cr3;
+
+        HASH_ADD( hh, obhk_ctx->hook_tbl, cr3, sizeof(target_ulong), ht_rec );
+    }
+
+    // check if any hook been implanted at the same address within a process
+    HASH_FIND( hh, ht_rec->proc_obhk_tbl, &addr, sizeof(target_ulong), ht_proc_rec );
+    if( ht_proc_rec == NULL ) {
+
+        // create the 2-layer hash table, indexed by user address
+        ht_proc_rec = (obhk_ht_record*)calloc( 1, sizeof(obhk_ht_record) );
+        if( ht_proc_rec == NULL ) {
+            obhook_errno = OBHOOK_ERR_FAIL;
+            goto obhk_add_fail;
+        }
+
+        ht_proc_rec->addr = addr;
+        ht_proc_rec->cr3  = cr3;
+
+        HASH_ADD( hh, ht_rec->proc_obhk_tbl, addr, sizeof(target_ulong), ht_proc_rec );
+    }
+
+
+    // allocate callback 
+    cb_rec = (obhk_cb_record*)calloc( 1, sizeof(obhk_cb_record) );
+    if( cb_rec == NULL ) {
+        obhook_errno = OBHOOK_ERR_FAIL;
+        goto obhk_add_fail;
+    }
+
+    // initialize the callback record
+    cb_rec->ht_rec    = ht_proc_rec;
+    cb_rec->uid       = new_uid;
+    cb_rec->enabled   = true;
+    cb_rec->universal = (cb_rec->ht_rec->cr3 == 0)? true : false;
+    cb_rec->cb_func   = cb;
+    strncpy( cb_rec->label, label, MAX_SZ_OBHOOK_LABEL );
+
+    // add the callback record to the linked list & index table
+    LL_APPEND( cb_rec->ht_rec->cb_list, cb_rec );
+    obhk_ctx->index_tbl[cb_rec->uid] = cb_rec;
+
+    // setup the flag indicating there are pending hooks
+    // to make codeblock re-translated
+    obhook_pending_hooks = true;
+
+    return cb_rec->uid;
+
+obhk_add_fail:
+    return -1;
+
+}
+
+/// Public API of Out-of-Box hook
+/// Each API function should be named with the prefix 'obhook_'
+int obhook_enable( int obhook_d ) {
+    return toggle_obhk( obhook_d, true );
+}
+
+int obhook_disable( int obhook_d ) {
+    return toggle_obhk( obhook_d, false );
+}
+
+int obhook_delete( int obhook_d ) {
+
+    obhk_ht_record* ht_rec;
+    obhk_cb_record* cb_rec;
+
+    // get the hook(callback function) record to be deleted
+    cb_rec = obhk_ctx->index_tbl[obhook_d];
+    if( cb_rec == NULL ) {
+        obhook_errno = OBHOOK_ERR_INVALID_DESCRIPTOR;
+        goto obhk_del_fail;
+    }
+
+    // acquire the hash table record containing the hook
+    ht_rec = cb_rec->ht_rec;
+
+    // remove the registered hook from linked list
+    LL_DELETE( ht_rec->cb_list, cb_rec );
+    
+    // remove the hash table record if no hook within
+    if( ht_rec->cb_list == NULL ) {
+
+        // delete & free from hash table
+        HASH_DEL( obhk_ctx->hook_tbl, ht_rec );
+        free( ht_rec );
+    }
+
+    // remove & free hook record from the fast index table
+    obhk_ctx->index_tbl[obhook_d] = NULL;
+    free( cb_rec );
+
+    return 0;
+
+obhk_del_fail:
+    return -1;
+}
+
+int obhook_list( void ) {
+
+    obhk_ht_record* ht_rec;
+    obhk_ht_record* ht_tmp;
+
+    obhk_ht_record* ht_proc_rec;
+    obhk_ht_record* ht_proc_tmp;
+
+    obhk_cb_record* cb_rec;
+
+    // list per-process hook
+    HASH_ITER( hh, obhk_ctx->hook_tbl, ht_rec, ht_tmp ) {
+
+        if( ht_rec == NULL )
+            break;
+
+        printf( "CR3: %016lx\n", ht_rec->cr3 );
+        HASH_ITER( hh, ht_rec->proc_obhk_tbl, ht_proc_rec, ht_proc_tmp ) {
+
+            if( ht_proc_rec == NULL )
+                break;
+            printf( "\t%016lx", ht_proc_rec->addr );
+            LL_FOREACH( ht_proc_rec->cb_list, cb_rec ) {
+                if( cb_rec == NULL )
+                    break;
+                printf( "(%d, %s, %d) ", cb_rec->uid, cb_rec->label, cb_rec->enabled );
+                cb_rec->cb_func(NULL);
+            }
+        }
+    }
+
+    printf( "\n" );
+    return -1;
+}
+
+int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void*) ) {
+    return add_obhk_internal( cr3, addr, label, cb );
+}
+
+int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void*) ) {
+    return add_obhk_internal( 0, kern_addr, label, cb );
+}

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -1,0 +1,92 @@
+/*
+ *  Out-of-Box Hook header
+ *
+ *  Copyright (c)   2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef __OBHOOK_H__
+#define __OBHOOK_H__
+
+#include "cpu.h"
+
+#define MAX_NM_OBHOOK       65535
+#define MAX_SZ_OBHOOK_LABEL 16
+
+enum OBHOOK_ERRNO {
+    OBHOOK_ERR_FAIL,
+    OBHOOK_ERR_FULL_HOOK,
+    OBHOOK_ERR_INVALID_ADDR,
+    OBHOOK_ERR_INVALID_LABEL,
+    OBHOOK_ERR_INVALID_CALLBACK,
+    OBHOOK_ERR_INVALID_DESCRIPTOR
+};
+typedef enum OBHOOK_ERRNO OBHOOK_ERRNO;
+
+extern OBHOOK_ERRNO obhook_errno;
+
+/// Add a process-aware, out-of-box hook toward the given process address.
+///
+///     \param  cr3     CR3 value of the targeted process
+///     \param  addr    process/user address to implant the hook
+///     \param  label   user-friendly name for the hook (optional, can be NULL)
+///     \param  cb      callback routine to be invoked when the hook is triggered
+///                     Note that each callback routine will be invoked and given
+///                     a pointer to the current CPU state structure
+///
+/// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
+extern int obhook_add_process( target_ulong cr3, target_ulong user_addr, char* label, void*(*cb) (void *) );
+
+/// Add an universal, out-of-box hook toward the given address
+///
+/// NOTE that the address should be kernel-level address, 
+/// it makes no sense to implant a universal hook at a user-level address, 
+/// which is in per-process, individual address space.
+///
+///     \param  addr    kernel address to implant the hook
+///     \param  label   user-friendly name for the hook (optional, can be NULL)
+///     \param  cb      callback routine to be invoked when the hook is triggered
+///                     Note that each callback routine will be invoked and given
+///                     a pointer to the current CPU state structure
+///
+/// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
+extern int obhook_add_universal( target_ulong kern_addr, char* label, void*(*cb) (void *) );
+
+/// Enable a out-of-box hook by the given descriptor
+///
+///     \param  obhook_d    descriptor of the hook to be enabled
+///
+/// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
+extern int obhook_enable( int obhook_d );
+
+/// Disable a out-of-box hook by the given descriptor
+///
+///     \param  obhook_d    descriptor of the hook to be disabled
+///
+/// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
+extern int obhook_disable( int obhook_d );
+
+/// Delete a out-of-box hook by the given descriptor
+///
+///     \param  obhook_d    decriptor of the hook to be deleted
+///
+/// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
+extern int obhook_delete( int obhook_d );
+
+/// List all registered out-of-box hook
+///
+/// Return 0 on success, -1 otherwise
+extern int obhook_list( void );
+
+#endif

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -19,6 +19,7 @@
 #ifndef __OBHOOK_H__
 #define __OBHOOK_H__
 
+#include <stdbool.h>
 #include "cpu.h"
 
 #define MAX_NM_OBHOOK       65535
@@ -35,18 +36,19 @@ enum OBHOOK_ERRNO {
 typedef enum OBHOOK_ERRNO OBHOOK_ERRNO;
 
 extern OBHOOK_ERRNO obhook_errno;
+extern bool obhook_pending_hooks;
 
-/// Add a process-aware, out-of-box hook toward the given process address.
+/// Add a process-aware, out-of-box hook toward the given address
 ///
 ///     \param  cr3     CR3 value of the targeted process
-///     \param  addr    process/user address to implant the hook
+///     \param  addr    address to implant the hook
 ///     \param  label   user-friendly name for the hook (optional, can be NULL)
 ///     \param  cb      callback routine to be invoked when the hook is triggered
 ///                     Note that each callback routine will be invoked and given
 ///                     a pointer to the current CPU state structure
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
-extern int obhook_add_process( target_ulong cr3, target_ulong user_addr, char* label, void*(*cb) (void *) );
+extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void *) );
 
 /// Add an universal, out-of-box hook toward the given address
 ///
@@ -61,7 +63,7 @@ extern int obhook_add_process( target_ulong cr3, target_ulong user_addr, char* l
 ///                     a pointer to the current CPU state structure
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
-extern int obhook_add_universal( target_ulong kern_addr, char* label, void*(*cb) (void *) );
+extern int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void *) );
 
 /// Enable a out-of-box hook by the given descriptor
 ///

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -19,10 +19,12 @@
 #ifndef __OBHOOK_H__
 #define __OBHOOK_H__
 
+#if !defined(CONFIG_OBHOOK_TEST)
 #include <stdbool.h>
 #include "uthash.h"
 #include "utlist.h"
 #include "cpu.h"
+#endif
 
 #define MAX_NM_OBHOOK       65535
 #define MAX_SZ_OBHOOK_LABEL 16
@@ -30,6 +32,7 @@
 enum OBHOOK_ERRNO {
     OBHOOK_ERR_FAIL,
     OBHOOK_ERR_FULL_HOOK,
+    OBHOOK_ERR_INVALID_CR3,
     OBHOOK_ERR_INVALID_ADDR,
     OBHOOK_ERR_INVALID_LABEL,
     OBHOOK_ERR_INVALID_CALLBACK,
@@ -109,7 +112,7 @@ extern bool obhook_pending_hooks;
 
 /// Add a process-aware, out-of-box hook at the given address
 ///
-///     \param  cr3     CR3 value of the targeted process
+///     \param  cr3     CR3 value of the targeted process, should not be zero
 ///     \param  addr    address to implant the hook
 ///     \param  label   user-friendly name for the hook (optional, can be NULL)
 ///     \param  cb      callback routine to be invoked when the hook is triggered
@@ -164,7 +167,7 @@ extern obhk_cb_record* obhook_getcbs_univ( target_ulong kern_addr );
 
 /// Get the callbacks of a per-process hook implanted at the specified address
 ///
-///     \param  cr3     CR3 value of the targeted process
+///     \param  cr3     CR3 value of the targeted process, should not be zero
 ///     \param  addr    address where the hook implanted at
 ///
 /// Return a pointer to the list of callbacks of the hook on success, NULL and obhook_errno iset otherwise

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -47,7 +47,7 @@ struct obhk_ht_record {
 
     target_ulong addr;
 
-    // cr3 = 0 indicates an universal hook
+    // cr3 = 0 is reserved for the universal hook
     target_ulong cr3;
 
     // used for per-process hook
@@ -134,6 +134,13 @@ extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* 
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void *) );
 
+/// Delete a out-of-box hook by the given descriptor
+///
+///     \param  obhook_d    decriptor of the hook to be deleted
+///
+/// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
+extern int obhook_delete( int obhook_d );
+
 /// Enable a out-of-box hook by the given descriptor
 ///
 ///     \param  obhook_d    descriptor of the hook to be enabled
@@ -148,11 +155,19 @@ extern int obhook_enable( int obhook_d );
 /// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_disable( int obhook_d );
 
-/// Delete a out-of-box hook by the given descriptor
+/// Get the callbacks of a universal hook implanted at the specified address
 ///
-///     \param  obhook_d    decriptor of the hook to be deleted
+///     \param  kern_addr   kernel address where the hook implanted at
 ///
-/// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
-extern int obhook_delete( int obhook_d );
+/// Return a pointer to the list of callbacks of the hook on success, NULL and obhook_errno iset otherwise
+extern obhk_cb_record* obhook_getcbs_univ( target_ulong kern_addr );
+
+/// Get the callbacks of a per-process hook implanted at the specified address
+///
+///     \param  cr3     CR3 value of the targeted process
+///     \param  addr    address where the hook implanted at
+///
+/// Return a pointer to the list of callbacks of the hook on success, NULL and obhook_errno iset otherwise
+extern obhk_cb_record* obhook_getcbs_proc( target_ulong cr3, target_ulong addr );
 
 #endif

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -20,6 +20,8 @@
 #define __OBHOOK_H__
 
 #include <stdbool.h>
+#include "uthash.h"
+#include "utlist.h"
 #include "cpu.h"
 
 #define MAX_NM_OBHOOK       65535
@@ -35,10 +37,77 @@ enum OBHOOK_ERRNO {
 };
 typedef enum OBHOOK_ERRNO OBHOOK_ERRNO;
 
+struct obhk_ht_record;
+struct obhk_cb_record;
+
+/// To keep the simplicity of implementation,
+/// obkh_ht_recrod as the hash table key is designed to support
+/// both per-process and universal hooks
+struct obhk_ht_record {
+
+    target_ulong addr;
+
+    // cr3 = 0 indicates an universal hook
+    target_ulong cr3;
+
+    // used for per-process hook
+    struct obhk_ht_record* proc_obhk_tbl;
+
+    // callback routines registered
+    struct obhk_cb_record* cb_list;
+
+    // handle for hash table
+    UT_hash_handle hh;
+};
+typedef struct obhk_ht_record obhk_ht_record;
+
+struct obhk_cb_record {
+
+    // a reverse-pointer to the hash table record
+    struct obhk_ht_record* ht_rec;
+
+    // unique identifier for each hook
+    uint16_t uid;
+
+    bool enabled;
+    bool universal;
+
+    // user-friendly label string
+    char label[MAX_SZ_OBHOOK_LABEL];
+
+    void* (*cb_func) (void*);
+
+    struct obhk_cb_record* next;
+};
+typedef struct obhk_cb_record obhk_cb_record; 
+
+struct obhook_context {
+
+    // 2-layers lookup hash table for out-of-box hook
+    //   The 1-layer is indexed by process CR3
+    //   The 2-layer is indexed by address where the hook implanted at
+    //
+    // Note that the hash record with CR3=0 indicates 
+    // the universal hooks, which are trigger regardless 
+    // of processes and the address is in kernel space.
+    obhk_ht_record* hook_tbl;
+
+    // the fast index table for queries to registered hook
+    obhk_cb_record* index_tbl[MAX_NM_OBHOOK];
+};
+typedef struct obhook_context obhook_context;
+
+/// Global context for out-of-box hooking
+///
+/// Instead of directly accessing this global
+/// context variable, using the obhook API on
+/// demands is suggested.
+extern obhook_context obhk_ctx[1];
+
 extern OBHOOK_ERRNO obhook_errno;
 extern bool obhook_pending_hooks;
 
-/// Add a process-aware, out-of-box hook toward the given address
+/// Add a process-aware, out-of-box hook at the given address
 ///
 ///     \param  cr3     CR3 value of the targeted process
 ///     \param  addr    address to implant the hook
@@ -50,17 +119,17 @@ extern bool obhook_pending_hooks;
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void *) );
 
-/// Add an universal, out-of-box hook toward the given address
+/// Add an universal, out-of-box hook at the given kernel-space address
 ///
-/// NOTE that the address should be kernel-level address, 
+/// NOTE that the address should be kernel-level address since 
 /// it makes no sense to implant a universal hook at a user-level address, 
 /// which is in per-process, individual address space.
 ///
-///     \param  addr    kernel address to implant the hook
-///     \param  label   user-friendly name for the hook (optional, can be NULL)
-///     \param  cb      callback routine to be invoked when the hook is triggered
-///                     Note that each callback routine will be invoked and given
-///                     a pointer to the current CPU state structure
+///     \param  kern_addr   kernel address to implant the hook
+///     \param  label       user-friendly name for the hook (optional, can be NULL)
+///     \param  cb          callback routine to be invoked when the hook is triggered
+///                         Note that each callback routine will be invoked and given
+///                         a pointer to the current CPU state structure
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void *) );
@@ -85,10 +154,5 @@ extern int obhook_disable( int obhook_d );
 ///
 /// Return 0 on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_delete( int obhook_d );
-
-/// List all registered out-of-box hook
-///
-/// Return 0 on success, -1 otherwise
-extern int obhook_list( void );
 
 #endif

--- a/ext/obhook/test/Makefile
+++ b/ext/obhook/test/Makefile
@@ -1,0 +1,25 @@
+CPP       = g++
+OBJ       = main.o obhook_unittest.o $(GTEST_LIB)
+LINKOBJ   = main.o obhook_unittest.o $(GTEST_LIB)
+LINKFLAGS = -lpthread -lgcov 
+BIN_DEST  = bin
+BIN       = $(BIN_DEST)/test_obhook
+CXXFLAGS  = -Wall -DCONFIG_OBHOOK_TEST -isystem ${GTEST_DIR}/include -isystem ${GMOCK_DIR}/include
+GCOV_FILE = *.gcno *.gcda *.gcov
+
+.PHONY: all clean
+
+all: $(BIN)
+
+clean:
+	rm -rf $(OBJ) $(BIN_DEST) $(GCOV_FILE)
+
+$(BIN): $(OBJ)
+	mkdir -p $(BIN_DEST)
+	$(CPP) $(LINKOBJ) -o $(BIN) $(LIBS) $(LINKFLAGS)
+
+main.o: main.cc
+	$(CPP) -c main.cc -o main.o $(CXXFLAGS)
+
+obhook_unittest.o: ../obhook.c obhook_unittest.cc
+	$(CPP) -c obhook_unittest.cc -o obhook_unittest.o $(CXXFLAGS)

--- a/ext/obhook/test/main.cc
+++ b/ext/obhook/test/main.cc
@@ -1,0 +1,26 @@
+/*
+ *  Out-of-Box Hooking unit testing
+ *
+ *  Copyright (c) 2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <gmock/gmock.h>
+
+int main( int argc, char* argv[] ) {
+    ::testing::InitGoogleMock( &argc, argv );
+    return RUN_ALL_TESTS();
+}

--- a/ext/obhook/test/obhook_unittest.cc
+++ b/ext/obhook/test/obhook_unittest.cc
@@ -42,7 +42,7 @@ struct mock_func : hook_func {
 
 } *mock_ptr;
 
-#define GEN_MOCK_OBJECT(x)  mock_func x; mock_ptr = &mock;
+#define GEN_MOCK_OBJECT(x)  mock_func x; mock_ptr = &x;
 
 // mock the functions in the original code
 #define calloc(x, y)      mock_ptr->calloc(x, y)

--- a/ext/obhook/test/obhook_unittest.cc
+++ b/ext/obhook/test/obhook_unittest.cc
@@ -1,0 +1,335 @@
+/*
+ *  Out-of-Box Hooking test cases
+ *
+ *  Copyright (c) 2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+
+// re-define certain header in order to decouple the QEMU dependency
+#include "../../../include/utlist.h"
+#include "../../../include/uthash.h"
+typedef uint64_t target_ulong;
+
+struct hook_func {
+
+    virtual ~hook_func() {};
+
+    // library API
+    virtual void* calloc( size_t, size_t ) = 0;
+
+    // obhook functions/API
+    virtual int  get_obhook_uid( void ) = 0;
+};
+
+struct mock_func : hook_func {
+    public:
+        MOCK_METHOD2( calloc, void*(size_t, size_t) );
+        MOCK_METHOD0( get_obhook_uid, int() );
+
+} *mock_ptr;
+
+#define GEN_MOCK_OBJECT(x)  mock_func x; mock_ptr = &mock;
+
+// mock the functions in the original code
+#define calloc(x, y)      mock_ptr->calloc(x, y)
+#define get_obhook_uid(x) mock_ptr->get_obhook_uid(x)
+
+extern "C" {
+#include "../obhook.c"
+}
+
+#undef calloc
+#undef get_obhook_uid
+
+// dummy callback for the obhook registration test
+void* dummy_cb( void* arg ) {
+    return NULL;
+}
+
+using namespace ::testing;
+
+TEST( GetUidTest, NormalCondition ) {
+    ASSERT_NE( -1, _get_obhook_uid() );
+}
+TEST( GetUidTest, FullCondition ) {
+
+    void* dummy = (void*)0xffffffffffffffff;
+
+    // exhausting available UID
+    for( int i = 0; i < MAX_NM_OBHOOK; ++i ) 
+        obhk_ctx->index_tbl[i] = (obhk_cb_record*)dummy;
+    // hook space should be (simulated) full now
+    ASSERT_EQ( -1, _get_obhook_uid() );
+
+    // restore shared resource
+    for( int i = 0; i < MAX_NM_OBHOOK; ++i ) 
+       obhk_ctx->index_tbl[i] = NULL;
+}
+
+TEST( KernelAddrCheckTest, ValidKernelAddress ) {
+    ASSERT_TRUE( is_kern_addr(0xffffffffffffffff) );
+    ASSERT_TRUE( is_kern_addr(0xffff0000ffff0000) );
+
+}
+TEST( KernelAddrCheckTest, InvalidKernelAddress ) {
+    ASSERT_FALSE( is_kern_addr(0x1234567812345678) );
+    ASSERT_FALSE( is_kern_addr(0x00007ffeb1234567) );
+}
+
+TEST( AddUnivHookTest, FullHookErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Return(-1) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_FULL_HOOK, obhook_errno );
+}
+TEST( AddUnivHookTest, InvalidAddressErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    ASSERT_EQ( -1, obhook_add_universal(0x0000000000000000, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_ADDR, obhook_errno );
+}
+TEST( AddUnivHookTest, LongLabelErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_LABEL, obhook_errno );
+}
+TEST( AddUnivHookTest, InvalidCallbackErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", NULL) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_CALLBACK, obhook_errno );
+}
+TEST( AddUnivHookTest, MemoryErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillOnce( ReturnNull() );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
+
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).Times(2).WillOnce( Invoke(calloc) ).WillOnce( ReturnNull() );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
+}
+TEST( AddUnivHookTest, NormalCondition ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    ASSERT_EQ( 0, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+}
+
+TEST( AddProcHookTest, InvalidCR3ErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    ASSERT_EQ( -1, obhook_add_process(0, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_CR3, obhook_errno );
+}
+TEST( AddProcHookTest, FullHookErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Return(-1) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_FULL_HOOK, obhook_errno );
+}
+TEST( AddProcHookTest, LongLabelErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_LABEL, obhook_errno );
+}
+TEST( AddProcHookTest, InvalidCallbackErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", NULL) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_CALLBACK, obhook_errno );
+}
+TEST( AddProcHookTest, MemoryErrorHandle ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillOnce( ReturnNull() );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
+
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).Times(2).WillOnce( Invoke(calloc) ).WillOnce( ReturnNull() );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
+}
+TEST( AddProcHookTest, NormalConditionWithUserAddr ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0x0000ffffffffffff, "label", dummy_cb) );
+}
+TEST( AddProcHookTest, NormalConditionWithKernAddr ) {
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+}
+
+TEST( GetUnivHookTest, HookFound ) {
+    
+    GEN_MOCK_OBJECT( mock );
+
+    int          hook_d   = -1;
+    target_ulong addr  = 0xffff0000ffff0000;
+    const char*  label = "label";
+
+    obhk_cb_record* rec;
+
+    // register a new universal hook
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    hook_d = obhook_add_universal( addr, label, dummy_cb );
+    ASSERT_NE( -1, hook_d );
+
+    // get the hook & check record
+    rec = obhook_getcbs_univ( addr );
+    ASSERT_TRUE( rec != NULL );
+    ASSERT_EQ( hook_d,  rec->uid );
+    ASSERT_TRUE( rec->universal );
+    ASSERT_TRUE( rec->enabled );
+    ASSERT_STREQ( label, rec->label );
+}
+TEST( GetUnivHookTest, HookNotFound ) {
+    GEN_MOCK_OBJECT( mock );
+    ASSERT_EQ( NULL, obhook_getcbs_univ(0xdeadbeefdeadbeed) );
+}
+
+TEST( GetProcHookTest, HookFound ) {
+    
+    GEN_MOCK_OBJECT( mock );
+
+    int          hook_d = -1;
+    target_ulong cr3    = 0x1234567812345678;
+    target_ulong addr   = 0xffff0000ffff0000;
+    const char*  label  = "proc_label";
+
+    obhk_cb_record* rec;
+
+    // register a new process hook
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    hook_d = obhook_add_process( cr3, addr, label, dummy_cb );
+    ASSERT_NE( -1, hook_d );
+
+    // get the hook & check record
+    rec = obhook_getcbs_proc( cr3, addr );
+    ASSERT_TRUE( rec != NULL );
+    ASSERT_EQ( hook_d,  rec->uid );
+    ASSERT_FALSE( rec->universal );
+    ASSERT_TRUE( rec->enabled );
+    ASSERT_STREQ( label, rec->label );
+
+}
+TEST( GetProcHookTest, HookNotFound ) {
+
+    GEN_MOCK_OBJECT( mock );
+    
+    target_ulong cr3   = 0x8765432187654321;
+    target_ulong addr  = 0xffff0000ffff0000;
+    const char*  label = "proc_label";
+
+    // register a new process hook
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    ASSERT_NE( -1, obhook_add_process(cr3, addr, label, dummy_cb) );
+
+    ASSERT_EQ( NULL, obhook_getcbs_proc(cr3 + 1, addr) );
+    ASSERT_EQ( NULL, obhook_getcbs_proc(cr3, addr + 1) );
+}
+TEST( GetPorcHookTest, InvalidCR3ErrorHandle ) {
+    ASSERT_EQ( NULL, obhook_getcbs_proc(0, 0x1234567812345678) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_CR3, obhook_errno );
+}
+
+TEST( ToggleHookTest, HookDisableAndEnable ) {
+
+    GEN_MOCK_OBJECT( mock );
+
+    int          hook_d;
+    target_ulong addr  = 0xffff0000ffff0001;
+    const char*  label = "label";
+
+    obhk_cb_record* rec;
+
+    // register a new universal hook
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    hook_d = obhook_add_universal( addr, label, dummy_cb );
+    ASSERT_NE( -1, hook_d );
+
+    // get the hook
+    rec = obhook_getcbs_univ( addr );
+    ASSERT_TRUE( rec != NULL );
+
+    // disable hook
+    ASSERT_EQ( 0, obhook_disable(hook_d) );
+    ASSERT_FALSE( rec->enabled );
+
+    // enable hook
+    obhook_enable( hook_d );
+    ASSERT_TRUE( rec->enabled );
+}
+TEST( ToggleHookTest, InvalidDescriptorErrorHandle ) {
+    ASSERT_EQ( -1, obhook_enable(MAX_NM_OBHOOK) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_enable(MAX_NM_OBHOOK+1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_enable(MAX_NM_OBHOOK-1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_enable(-1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+   
+    ASSERT_EQ( -1, obhook_disable(MAX_NM_OBHOOK) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_disable(MAX_NM_OBHOOK+1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_disable(MAX_NM_OBHOOK-1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_disable(-1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+}
+
+TEST( DeleteHookTest, InvalidDescriptorErroHandle ) {
+    ASSERT_EQ( -1, obhook_delete(MAX_NM_OBHOOK) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_delete(MAX_NM_OBHOOK+1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_delete(MAX_NM_OBHOOK-1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+    ASSERT_EQ( -1, obhook_delete(-1) );
+    ASSERT_EQ( OBHOOK_ERR_INVALID_DESCRIPTOR, obhook_errno );
+}
+TEST( DeleteHookTest, NormalCondition ) {
+ 
+    int hook_d = -1;
+    
+    target_ulong cr3  = 0x8765432187654321;
+    target_ulong addr = 0xffffffffffffffff;
+
+    GEN_MOCK_OBJECT( mock );
+    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
+    
+    hook_d = obhook_add_process( cr3, addr, "to_be_deleted", dummy_cb );
+    ASSERT_NE( -1, hook_d );
+    ASSERT_TRUE( obhk_ctx->index_tbl[hook_d] != NULL );
+    
+    ASSERT_EQ( 0, obhook_delete(hook_d) );
+    ASSERT_EQ( NULL, obhk_ctx->index_tbl[hook_d] );
+}

--- a/target-i386/Makefile.objs
+++ b/target-i386/Makefile.objs
@@ -7,3 +7,6 @@ obj-$(CONFIG_KVM) += kvm.o
 obj-$(call lnot,$(CONFIG_KVM)) += kvm-stub.o
 obj-$(CONFIG_LINUX_USER) += ioport-user.o
 obj-$(CONFIG_BSD_USER) += ioport-user.o
+
+# MBA helpers for extensions, the .c should be empty if no extensions is enabled
+obj-y += mba_helper.o

--- a/target-i386/helper.h
+++ b/target-i386/helper.h
@@ -16,6 +16,10 @@ DEF_HELPER_2(divq_EAX, void, env, tl)
 DEF_HELPER_2(idivq_EAX, void, env, tl)
 #endif
 
+#if defined(CONFIG_OBHOOK)
+DEF_HELPER_1(obhook_dispatcher, void, env)
+#endif
+
 DEF_HELPER_2(aam, void, env, int)
 DEF_HELPER_2(aad, void, env, int)
 DEF_HELPER_1(aaa, void, env)

--- a/target-i386/mba_helper.c
+++ b/target-i386/mba_helper.c
@@ -1,0 +1,52 @@
+/*
+ *  MBA helpers implementation, including
+ *      Out-of-Box Hook
+ *
+ *  Copyright (c)   2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cpu.h"
+#include "exec/helper-proto.h"
+
+#if defined(CONFIG_OBHOOK)
+#include "../ext/obhook/obhook.h"
+#endif
+
+#if defined(CONFIG_OBHOOK)
+void helper_obhook_dispatcher( CPUX86State* env ) {
+
+    obhk_cb_record* cb_list = NULL;
+    obhk_cb_record* cb_rec;
+
+    // invoke universal hook
+    cb_list = obhook_getcbs_univ( env->eip );
+    if( cb_list != NULL ) {
+        LL_FOREACH( cb_list, cb_rec ) {
+            if( cb_rec->enabled )
+                cb_rec->cb_func( env );
+        }
+    }
+
+    // invoke per-process hook
+    cb_list = obhook_getcbs_proc( env->cr[3], env->eip );
+    if( cb_list != NULL ) {
+        LL_FOREACH( cb_list, cb_rec ) {
+            if( cb_rec->enabled )
+                cb_rec->cb_func( env );
+        }
+    }
+}
+#endif

--- a/target-i386/translate.c
+++ b/target-i386/translate.c
@@ -38,6 +38,10 @@
 #include "ext/dift/dift.h"
 #endif
 
+#if defined(CONFIG_OBHOOK)
+#include "ext/obhook/obhook.h"
+#endif
+
 
 #define PREFIX_REPZ   0x01
 #define PREFIX_REPNZ  0x02
@@ -5203,6 +5207,14 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
 #endif
         );
     }
+#endif
+
+#if defined(CONFIG_OBHOOK)
+    /// if any out-of-box hook is desired to be implanted
+    /// generate the helper function as the runtime dispatcher
+    if( obhook_getcbs_univ(s->pc) != NULL 
+     || obhook_getcbs_proc(env->cr[3], s->pc) != NULL )
+        gen_helper_obhook_dispatcher( cpu_env );
 #endif
 
     s->pc++;


### PR DESCRIPTION
The OBHook extension supports both _process-aware_ and _universal_ hooks toward the guest OS.
The implementation is purely hypervisor(QEMU)-based by instrumenting the CPU emulation to ensure the transparency of the implanted hooks.