### PR TITLE
Fix a segfault bug and a hardcoded compile path in memfrs.

### DIFF
--- a/ext/memfrs/memfrs-commands.c
+++ b/ext/memfrs/memfrs-commands.c
@@ -276,6 +276,7 @@ void do_get_gvar_vmem(Monitor *mon, const QDict *qdict)
    }
     
    gvar = memfrs_q_globalvar(name);
-   monitor_printf(mon, "%s @ %"PRIx64"\n", name, memfrs_gvar_offset(gvar) + base);
+   if( gvar != NULL )
+       monitor_printf(mon, "%s @ %"PRIx64"\n", name, memfrs_gvar_offset(gvar) + base);
    return; 
 }

--- a/ext/memfrs/pdbparser/.gitignore
+++ b/ext/memfrs/pdbparser/.gitignore
@@ -1,0 +1,4 @@
+pdb_parser
+type_definition.json
+global_variable.json
+!compile.sh

--- a/ext/memfrs/pdbparser/compile.sh
+++ b/ext/memfrs/pdbparser/compile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+gcc -g \
+    -I../../../include/ -I../../../json-c/ -I../../../json-c/tests/ \
+    pdb_parser.c pdb.c  \
+    stream_file.c tpi.c \
+    dbi.c gdata.c stream_pe.c omap.c \
+    ../../../json-c/.libs/libjson-c.a \
+    -o pdb_parser

--- a/ext/memfrs/pdbparser/pdb.c
+++ b/ext/memfrs/pdbparser/pdb.c
@@ -311,7 +311,7 @@ void dump_gvar_json(R_PDB *pdb)
 	}
 
         DL_FOREACH(gsym_data_stream->globals_list, gdata){
-                sctn_header = utarray_eltptr(pe_stream->sections_hdrs, (gdata->segment -1));
+                sctn_header = (SIMAGE_SECTION_HEADER*)utarray_eltptr(pe_stream->sections_hdrs, (gdata->segment -1));
                 if (sctn_header) {
 			char *name = gdata->name.name;
                         printf("name found: %s %x %d %s\n", name, sctn_header->virtual_address+gdata->offset, gdata->symtype, sctn_header->name);

--- a/ext/memfrs/pdbparser/pdb_parse.sh
+++ b/ext/memfrs/pdbparser/pdb_parse.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-gcc -g -I../../../include/ -I../../../json-c/ -I../../../json-c/tests/ pdb_parser.c pdb.c stream_file.c tpi.c dbi.c gdata.c stream_pe.c omap.c ../../../json-c/.libs/libjson-c.a && ./a.out /home/bletchley/tkrnlmp.pdb

--- a/ext/memfrs/pdbparser/pdb_parser.c
+++ b/ext/memfrs/pdbparser/pdb_parser.c
@@ -23,15 +23,24 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "pdb.h"
 
 int main(int argc, char *argv[])
 {
+    if( argc != 2 ) {
+        printf( "Usage: %s <PDB_FILE>\n\n", argv[0] );
+        printf( "Generate two JSON file: \n\
+    1. type_definition.json - data structure information\n\
+    2. global_variable.json - global variable offset information\n" );
+        exit( 1 );
+    }
+
     R_PDB pdb = {0};
     init_pdb_parser(&pdb, argv[1]);
     printf("Start parsing pdb file\n");
     pdb7_parse(&pdb);
-    printf("Dumping structure information\n");    
+    printf("Dumping structure information\n");
     dump_json(&pdb);
     printf("Dumping global offset information\n");
     dump_gvar_json(&pdb);


### PR DESCRIPTION
1. fix the bug which try to get global variable offset on NULL json object
2. rename pdb_parse.sh to compile.sh and fix the hardcoded path
3. add parameter check and usage information for the pdb_parser