### PR TITLE
Fix DIFT bugs and re-design the swith on/off feature

### DIFF
--- a/ext/dift/dift-commands.c
+++ b/ext/dift/dift-commands.c
@@ -91,25 +91,15 @@ void do_get_physic_address(struct Monitor *mon, const struct QDict *qdict)
 
 void do_enable_dift(struct Monitor *mon, const struct QDict *qdict )
 {
-    CPUArchState* env;
-
     if( dift_is_enabled() )
         return;
-    
-    env = (CPUArchState*)mba_mon_get_cpu();
-    tb_flush( env );
     dift_enable();
 }
 
 void do_disable_dift(struct Monitor *mon, const struct QDict *qdict)
 {
-    CPUArchState* env;
-
     if( !dift_is_enabled() )
         return;
-    
-    env = (CPUArchState*)mba_mon_get_cpu();
-    tb_flush( env );
     dift_disable();
 }
 

--- a/ext/dift/dift.c
+++ b/ext/dift/dift.c
@@ -780,8 +780,13 @@ static void _MOCKABLE(wait_dift_analysis)( void ) {
 
 static int _MOCKABLE(is_valid_mem_range)( uint64_t addr, uint64_t len ) {
 
-    if( phys_ram_size < addr || phys_ram_size - addr < len )
+    if( 
+        (phys_ram_size < addr || phys_ram_size - addr < len)
+    &&  addr != clean_source
+    &&  addr != null_sink 
+    )
         return false;
+
     return true;
 }
 // DIFT Private API - Memory taint operation

--- a/ext/dift/dift.c
+++ b/ext/dift/dift.c
@@ -86,6 +86,9 @@ uint64_t phys_ram_size = 0;
 
 FILE* dift_logfile = NULL;
 
+bool dift_switch_pending = false;
+bool dift_enabled        = false;
+
 // Emulator part
 uint8_t pre_generated_routine[4096] __attribute__((aligned(4096)));
 uint8_t* rt_get_next_enqptr     = pre_generated_routine;
@@ -314,7 +317,6 @@ dift_context dc[1] __attribute__((aligned(4096)));
 
 // DIFT private variable
 static int  sleepness = 0;
-static bool dift_enabled = false;
 static pthread_t dift_thread;
 
 const char* REG_NAME[] = {
@@ -1292,11 +1294,13 @@ CONTAMINATION_RECORD dift_get_disk_dirty( uint64_t haddr ) {
 }
 
 void dift_enable( void ) {
-    dift_enabled = true;
+    if( !dift_enabled )
+        dift_switch_pending = true;
 }
 
 void dift_disable( void ) {
-    dift_enabled = false;
+    if( dift_enabled )
+        dift_switch_pending = true;
 }
 
 bool dift_is_enabled( void ) {

--- a/ext/dift/dift.c
+++ b/ext/dift/dift.c
@@ -296,10 +296,10 @@ uint16_t case_list[] ={
         XMM_EFFECT_CLEAR,                                                            // 79
 };
 
-uint32_t dift_code_top =  1;  // Loc 0 is reserved for the workaround in add_file_taint
+uint32_t dift_code_top  = 0;
 uint32_t dift_code_cntr = 0;
-uint32_t dift_code_loc;
-uint32_t dift_code_off;
+uint32_t dift_code_loc  = 0;
+uint32_t dift_code_off  = 0;
 
 // The size of the allocation should be fixed
 uint64_t dift_code_buffer[CONFIG_MAX_TB_ESTI * CONFIG_IF_CODES_PER_TB] __attribute__((aligned(4096)));    
@@ -1138,23 +1138,19 @@ void dift_sync( void ) {
 
     uint64_t rec = 0;
 
-    if( dift_code_loc != 0 ) {
+    rec |=  dift_code_loc;
+    rec <<= 0x10;
 
-        rec |=  dift_code_loc;
-        rec <<= 0x10;
+    rec |=  dift_code_cntr;
+    rec <<= 0x10;
 
-        rec |=  dift_code_cntr;
-        rec <<= 0x10;
-
-        dift_rec_enqueue( REC_END_SYMBOL | REC_BEFORE_BLOCK_BEGIN );
-        dift_rec_enqueue( rec );
-    }
+    dift_rec_enqueue( REC_END_SYMBOL | REC_BEFORE_BLOCK_BEGIN );
+    dift_rec_enqueue( rec );
 
     dift_rec_enqueue( REC_END_SYMBOL | REC_SYNC );
     kick_enqptr();
     wait_dift_analysis();
 
-    dift_code_loc = 0;
     dift_code_cntr = 0;
     
     dift_thread_ok_signal = 0;

--- a/ext/dift/dift.h
+++ b/ext/dift/dift.h
@@ -373,6 +373,9 @@ typedef struct dift_record  dift_record;
 
 extern const dift_record DIFT_REC_EMPTY;
 
+extern bool dift_switch_pending;
+extern bool dift_enabled;
+
 extern uint64_t phys_ram_base;
 extern uint64_t phys_ram_size;
 

--- a/target-i386/translate.c
+++ b/target-i386/translate.c
@@ -732,6 +732,9 @@ static void gen_dift_block_begin( DisasContext* s ) {
 
     uint64_t rec = REC_BLOCK_BEGIN;
 
+    if( !dift_is_enabled() )
+        return;
+
 #if defined(CONFIG_DIFT_DEBUG)
     qemu_log( "gen_dift_block_begin, tb->dift_code_loc = %08x\n", s->tb->dift_code_loc / CONFIG_IF_CODES_PER_TB );
 #endif
@@ -9417,7 +9420,6 @@ static inline void gen_intermediate_code_internal(X86CPU *cpu,
 
         dift_code_off = dift_code_cntr;
         dift_sync();
-        dift_code_loc = (dc->tb->dift_code_loc / CONFIG_IF_CODES_PER_TB);
     }
     label_or_helper_appeared = 0;
 #endif

--- a/tcg/i386/tcg-target.c
+++ b/tcg/i386/tcg-target.c
@@ -1787,16 +1787,15 @@ static void tcg_out_qemu_dift_inc_diftcodes( TCGContext* s, const TCGArg* args )
     tcg_out8(s, 0xb8);
     tcg_out64(s, (uint64_t)args[0]);         // mov rax, args[0]
 
-    tcg_out8(s, 0x48);
     tcg_out8(s, 0xa3);
-    tcg_out64(s, (uint64_t)&dift_code_cntr); // mov [&dift_code_cntr], rax
+    tcg_out64(s, (uint64_t)&dift_code_cntr); // mov [&dift_code_cntr], eax
 }
 
 static void tcg_out_qemu_dift_tb_begin( TCGContext* s, const TCGArg* args ) {
 
     tcg_out8(s, 0x48);
     tcg_out8(s, 0xba);
-    tcg_out64(s, REC_END_SYMBOL | REC_BEFORE_BLOCK_BEGIN);  // mov rdx, REC_BEFORE_BLOCK_BEGIN
+    tcg_out64(s, REC_END_SYMBOL | REC_BEFORE_BLOCK_BEGIN);  // mov rdx, REC_END_SYMBOL | REC_BEFORE_BLOCK_BEGIN
 
     tcg_out8(s, 0x48);
     tcg_out8(s, 0xb8);

--- a/translate-all.c
+++ b/translate-all.c
@@ -783,7 +783,7 @@ void tb_flush(CPUArchState *env1)
 
 #if defined(CONFIG_DIFT)
     dift_sync();
-    dift_code_top = 1; // loc 0 is reserved for the case REC_SYNC
+    dift_code_top = 0;
 #endif
 
 #if defined(DEBUG_FLUSH)


### PR DESCRIPTION
1. re-design DIFT switch into asynchronous request to make QEMU main thread flush TBs
2. fix the bug that executing 64bits 'MOV' instructions on the 32bits variable dift_code_cntr
3. revise the testing code for warning-free and fitting to the new design of DIFT switch
4. fix the erroneous memory range check on clean taint source and null taint sink