### PR TITLE
Agent Module Modifications

### DIFF
--- a/ext/agent/agent-commands-spec.h
+++ b/ext/agent/agent-commands-spec.h
@@ -61,3 +61,10 @@
     .help         = "Create an agent thread to communicate with Windows in-VM agent server.",
     .mhandler.cmd = do_win_init,
 },
+{
+    .name         = "w_reset",
+    .args_type    = "", 
+    .params       = "",
+    .help         = "Reset the agent client to the condition before w_init.",
+    .mhandler.cmd = do_win_reset,
+},

--- a/ext/agent/agent-commands-spec.h
+++ b/ext/agent/agent-commands-spec.h
@@ -62,6 +62,13 @@
     .mhandler.cmd = do_win_init,
 },
 {
+    .name         = "w_sync",
+    .args_type    = "", 
+    .params       = "",
+    .help         = "Flush the Guest OS cache.",
+    .mhandler.cmd = do_win_sync,
+},
+{
     .name         = "w_reset",
     .args_type    = "", 
     .params       = "",

--- a/ext/agent/agent-commands.c
+++ b/ext/agent/agent-commands.c
@@ -244,3 +244,59 @@ void do_win_init( Monitor *mon, const QDict *qdict )
 
 }
 
+void do_win_reset( Monitor *mon, const QDict *qdict ) {
+
+    MBA_AGENT_RETURN ret;
+    
+    // counter (down) for port forwarding setup try
+    int try_countdown = 10; 
+
+    uint16_t fwd_port;
+    char     fwd_config[32];
+        
+    if ( agent_is_ready()==0 ) {
+        monitor_printf( mon, "Agent client has not started\n" );
+        return;
+    }
+
+    // setup port forwarding for in-VM agent server, 10 times trying with random port
+    srand( time(NULL) );
+    while( try_countdown ) { 
+
+        fwd_port  = rand() % 65535;
+        fwd_port += (fwd_port < 1024 )? 1024 : 0;
+
+        bzero( fwd_config, sizeof(fwd_config) );
+        snprintf( fwd_config, 32, "tcp:%d::%d", fwd_port, AGENT_GUEST_PORT );
+
+        if( net_slirp_redir(fwd_config) == 0 ) 
+            break;
+
+        --try_countdown;
+    }   
+
+    if( try_countdown == 0 ) { 
+        monitor_printf( mon, "Agent port forwarding setup failed\n" );
+        return;
+    }   
+
+    ret = agent_reset( mon );
+    switch( ret ) { 
+
+        case AGENT_RET_SUCCESS:
+            monitor_printf( mon, "Agent thread has been reset\n" );
+            break;
+
+        case AGENT_RET_EBUSY:
+            monitor_printf( mon, "Agent is busy handling the previous command. Come back later\n" );
+            break;
+
+        case AGENT_RET_EFAIL:
+            monitor_printf( mon, "Agent thread reset failed\n" );
+            break;
+
+        default:
+            monitor_printf( mon, "Unkown error when reseting agent\n" );
+            break;
+    }
+}

--- a/ext/agent/agent-commands.h
+++ b/ext/agent/agent-commands.h
@@ -29,5 +29,6 @@ void do_win_exec(struct Monitor *mon, const struct QDict *qdict);
 void do_win_invo(struct Monitor *mon, const struct QDict *qdict);
 void do_win_logf(struct Monitor *mon, const struct QDict *qdict);
 void do_win_init(struct Monitor *mon, const struct QDict *qdict);
+void do_win_sync(struct Monitor *mon, const struct QDict *qdict);
 void do_win_reset(struct Monitor *mon, const struct QDict *qdict);
 #endif

--- a/ext/agent/agent-commands.h
+++ b/ext/agent/agent-commands.h
@@ -29,4 +29,5 @@ void do_win_exec(struct Monitor *mon, const struct QDict *qdict);
 void do_win_invo(struct Monitor *mon, const struct QDict *qdict);
 void do_win_logf(struct Monitor *mon, const struct QDict *qdict);
 void do_win_init(struct Monitor *mon, const struct QDict *qdict);
+void do_win_reset(struct Monitor *mon, const struct QDict *qdict);
 #endif

--- a/ext/agent/agent.h
+++ b/ext/agent/agent.h
@@ -29,10 +29,10 @@
 #define SZ_MAX_FILEPATH  256
 #define SZ_MAX_FILECHUNK 8192 // 8KB per I/O chunk
 
-#define MSG_EXEC_READY "EXEC_READY"
-#define MSG_ACK_PREFIX "System Receive : "
+#define MSG_EXEC_READY  "EXEC_READY"
+#define MSG_ACK_PREFIX  "System Receive : "
 #define MSG_REC_SUCCESS "SUCCESS"
-#define MSG_REC_FAIL "CMDFAIL"
+#define MSG_REC_FAIL    "CMDFAIL"
 
 // performing agent action
 enum MBA_AGENT_ACTION {
@@ -154,5 +154,16 @@ extern MBA_AGENT_RETURN agent_logfile( const char* dst_path );
 ///        AGENT_RET_EBUSY, the agent thread is still busy dealing the initialization
 ///        AGENT_RET_EFAIL, general failure
 extern MBA_AGENT_RETURN agent_init( Monitor* mon, uint16_t server_fwd_port );
+
+/// Reset agent context
+/// This API should be called before any other 'agent_xxx' can be used
+/// 
+///        \param none 
+///
+/// Return AGENT_RET_SUCCESS, no error occured
+///        AGENT_RET_EBUSY, the agent thread is still busy dealing the initialization
+///        AGENT_RET_EFAIL, general failure
+extern MBA_AGENT_RETURN agent_reset( Monitor* mon );
+
 #endif
 

--- a/ext/agent/agent.h
+++ b/ext/agent/agent.h
@@ -43,6 +43,7 @@ enum MBA_AGENT_ACTION {
     AGENT_ACT_EXEC,
     AGENT_ACT_INVO,
     AGENT_ACT_LOGF,
+    AGENT_ACT_SYNC,
 };
 
 // common return value
@@ -148,20 +149,28 @@ extern MBA_AGENT_RETURN agent_logfile( const char* dst_path );
 /// This API should be called before any other 'agent_xxx' can be used
 /// 
 ///        \param mon              monitor of QEMU, allowing agent extension to show message
-///        \param server_fwd_port  the local port number to forward network connections to the in-VM agent
+///        \param server_fwd_port  the local port number to forward network connections to the in-VM agent.
+///                                0 means to new a fwd_port(w_init), and non-zero means to use the previous fwd_port(agent_reset)
+///        \param fwd_port         the function pointer to the net_slirp_redir to do the redirection of port
 ///
 /// Return AGENT_RET_SUCCESS, no error occured
 ///        AGENT_RET_EBUSY, the agent thread is still busy dealing the initialization
 ///        AGENT_RET_EFAIL, general failure
-extern MBA_AGENT_RETURN agent_init( Monitor* mon, uint16_t server_fwd_port );
+extern MBA_AGENT_RETURN agent_init( Monitor* mon, uint16_t server_fwd_port, int(*fwd_port)(const char*) );
 
-/// Reset agent context
-/// This API should be called before any other 'agent_xxx' can be used
-/// 
-///        \param none 
+/// Flush the cache to disk in guest OS 
+///
+///        no param
 ///
 /// Return AGENT_RET_SUCCESS, no error occured
-///        AGENT_RET_EBUSY, the agent thread is still busy dealing the initialization
+///        AGENT_RET_EFAIL, general failure
+extern MBA_AGENT_RETURN agent_sync( void );
+
+/// Reset agent context
+/// 
+///        \param mon              monitor of QEMU, allowing reconnect to agent server by agent_init
+///
+/// Return AGENT_RET_SUCCESS, no error occured
 ///        AGENT_RET_EFAIL, general failure
 extern MBA_AGENT_RETURN agent_reset( Monitor* mon );
 

--- a/ext/agent/test/agent_unittest.cc
+++ b/ext/agent/test/agent_unittest.cc
@@ -25,9 +25,10 @@
 #include <set>
 #include <inttypes.h>
 
-extern "C" {
-#include "../agent.c"
+typedef void Monitor;
 
+extern "C" {
+#include "../agent.h"
 }
 
 struct hook_functions {
@@ -49,49 +50,63 @@ struct hook_functions {
     virtual MBA_AGENT_RETURN execute_guest_cmd_return( void ) = 0;
     virtual MBA_AGENT_RETURN execute_guest_cmd_noreturn( void ) = 0;
     virtual MBA_AGENT_RETURN export_agent_log( void ) = 0;
+    virtual MBA_AGENT_RETURN sync_cache( void ) = 0;
     virtual int connect_agent_server( void ) = 0;
     virtual bool agent_is_ready( void ) = 0;
     virtual bool agent_is_exec( void ) = 0;
-    virtual void agent_printf( const char*, ... ) = 0;
+    virtual void agent_printf( const char* ) = 0;
     virtual MBA_AGENT_RETURN agent_import( const char*, const char* ) = 0;
     virtual MBA_AGENT_RETURN agent_export( const char*, const char* ) = 0;
     virtual MBA_AGENT_RETURN agent_execute( const char* ) = 0;
     virtual MBA_AGENT_RETURN agent_invoke( const char* ) = 0;
     virtual MBA_AGENT_RETURN agent_logfile( const char* ) = 0;
-    virtual MBA_AGENT_RETURN agent_init( Monitor*, uint16_t ) = 0;
+    virtual MBA_AGENT_RETURN agent_sync( void ) = 0;
+    virtual MBA_AGENT_RETURN agent_init( Monitor*, uint16_t, int(*)(const char*)) = 0;
 };
 
 struct mock_functions : hook_functions {
-    MOCK_METHOD1( exit, void( int ) )
-    MOCK_METHOD4( pthread_create, int(pthread_t*, const pthread_attr_t*, void*(*)(void*), void* ) )
-    MOCK_METHOD2( fopen, FILE*(const char *, const char *) )
-    MOCK_METHOD3( write, int(int, void*, int) )
-    MOCK_METHOD3( read, int(int, void*, int) )
+    MOCK_METHOD1( exit, void( int ) );
+    MOCK_METHOD4( pthread_create, int(pthread_t*, const pthread_attr_t*, void*(*)(void*), void* ) );
+    MOCK_METHOD2( pthread_mutex_init, int( pthread_mutex_t*, const pthread_mutexattr_t* ));
+    MOCK_METHOD2( pthread_cond_init, int(pthread_cond_t*, const pthread_condattr_t*));
+    MOCK_METHOD2( fopen, FILE*(const char *, const char *) );
+    MOCK_METHOD3( write, int(int, void*, int) );
+    MOCK_METHOD3( read, int(int, void*, int) );
 
-    MOCK_METHOD0( agent_cleanup, void( void ) )
-    MOCK_METHOD3( as_write, ssize_t( int, void*, size_t ) )
-    MOCK_METHOD3( as_read, ssize_t( int, void*, size_t ) )
-    MOCK_METHOD0( import_host_file, MBA_AGENT_RETURN( void ) )
-    MOCK_METHOD0( export_guest_fil, MBA_AGENT_RETURN( void ) )
-    MOCK_METHOD0( execute_guest_cmd_return, MBA_AGENT_RETURN( void ) )
-    MOCK_METHOD0( execute_guest_cmd_noreturn, MBA_AGENT_RETURN( void ) )
-    MOCK_METHOD0( export_agent_log, MBA_AGENT_RETURN( void ) )
-    MOCK_METHOD0( connect_agent_server, int( void ) )
-    MOCK_METHOD0( agent_is_ready, bool( void ) )
-    MOCK_METHOD0( agent_is_exec, bool( void ) )
-    MOCK_METHOD2( agent_printf, void(const char*, ...) )
-    MOCK_METHOD2( agent_import, MBA_AGENT_RETURN( const char*, const char* ) )
-    MOCK_METHOD2( agent_export, MBA_AGENT_RETURN( const char*, const char* ) )
-    MOCK_METHOD1( agent_execute, MBA_AGENT_RETURN( const char* ) )
-    MOCK_METHOD1( agent_invoke, MBA_AGENT_RETURN( const char* ) )
-    MOCK_METHOD1( agent_logfile, MBA_AGENT_RETURN( const char* ) )
-    MOCK_METHOD2( agent_init, MBA_AGENT_RETURN( Monitor*, uint16_t ) )
+    MOCK_METHOD0( agent_cleanup, void( void ) );
+    MOCK_METHOD3( as_write, ssize_t( int, void*, size_t ) );
+    MOCK_METHOD3( as_read, ssize_t( int, void*, size_t ) );
+    MOCK_METHOD0( import_host_file, MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD0( export_guest_file, MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD0( execute_guest_cmd_return, MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD0( execute_guest_cmd_noreturn, MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD0( export_agent_log, MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD0( sync_cache,  MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD0( connect_agent_server, int( void ) );
+    MOCK_METHOD0( agent_is_ready, bool( void ) );
+    MOCK_METHOD0( agent_is_exec, bool( void ) );
+    MOCK_METHOD1( agent_printf, void(const char*) );
+    MOCK_METHOD2( agent_import, MBA_AGENT_RETURN( const char*, const char* ) );
+    MOCK_METHOD2( agent_export, MBA_AGENT_RETURN( const char*, const char* ) );
+    MOCK_METHOD1( agent_execute, MBA_AGENT_RETURN( const char* ) );
+    MOCK_METHOD1( agent_invoke, MBA_AGENT_RETURN( const char* ) );
+    MOCK_METHOD1( agent_logfile, MBA_AGENT_RETURN( const char* ) );
+    MOCK_METHOD0( agent_sync, MBA_AGENT_RETURN( void ) );
+    MOCK_METHOD3( agent_init, MBA_AGENT_RETURN( Monitor*, uint16_t, int(*)(const char*)) );
 } *mock_ptr;
+
+extern "C" {
+#include "../agent.c"
+}
 
 #undef exit
 #undef pthread_create
+#undef pthread_mutex_init
+#undef pthread_cond_init
 #undef fopen
-#undef agent_clenup
+#undef write
+#undef read
+#undef agent_cleanup
 #undef as_write
 #undef as_read
 #undef import_host_file
@@ -99,6 +114,7 @@ struct mock_functions : hook_functions {
 #undef execute_guest_cmd_return
 #undef execute_guest_cmd_noreturn
 #undef export_agent_log
+#undef sync_cache
 #undef connect_agent_server
 #undef agent_is_ready
 #undef agent_is_exec
@@ -108,6 +124,7 @@ struct mock_functions : hook_functions {
 #undef agent_execute
 #undef agent_invoke
 #undef agent_logfile
+#undef agent_sync
 #undef agent_init
 
 #define GEN_MOCK_OBJECT( x )  mock_functions x; mock_ptr = &x;
@@ -119,29 +136,29 @@ protected:
     virtual void SetUp() {
         GEN_MOCK_OBJECT( mock );
 
-        EXPECT_CALLL( mock, agent_is_ready() ).WillOnce( Return( true ) );
-        EXPECT_CALLL( mock, pthread_mutex_init(_,_) ).WillOnce( Return( 0 ) );
-        EXPECT_CALLL( mock, pthread_mutex_init(_,_) ).WillOnce( Return( 0 ) );
-        EXPECT_CALLL( mock, pthread_cond_init(_,_) ).WillOnce( Return( 0 ) );
-        EXPECT_CALLL( mock, pthread_create(_,_,_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALL( mock, agent_is_ready() ).WillOnce( Return( true ) );
+        EXPECT_CALL( mock, pthread_mutex_init(_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALL( mock, pthread_mutex_init(_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALL( mock, pthread_cond_init(_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALL( mock, pthread_create(_,_,_,_) ).WillOnce( Return( 0 ) );
 
-        _agent_init(NULL, 8888);
+        _agent_init(NULL, 8888, NULL);
 
-    }
+    };
     virtual void TearDown() {
         // No recycable due to all initializations mocked
-    }
-}
+    };
+};
 
 // Static Functions Testing
-TEST ( Agent_Init, WRITE_FAIL ) {
+TEST_F ( FixtureAgentContextInitilizes, WRITE_FAIL ) {
     GEN_MOCK_OBJECT( mock );
     
     EXPECT_CALL( mock, write(_,_,_) ).WillOnce( Return(-1) );
-    EXPECT_CALL( mock, agent_printf("The connection to the agent server is broken while reading\n") ).Times( 1 )
-    EXPECT_CALL( mock, agent_clenup() ).Times( 1 );
+    EXPECT_CALL( mock, agent_printf("The connection to the agent server is broken while reading\n") ).Times( 1 );
+    EXPECT_CALL( mock, agent_cleanup() ).Times( 1 );
 
-    _agent_init();
+    _agent_init(NULL, 1111, NULL);
 }
 
 

--- a/ext/agent/test/agent_unittest.cc
+++ b/ext/agent/test/agent_unittest.cc
@@ -25,21 +25,126 @@
 #include <set>
 #include <inttypes.h>
 
-struct dift_context;
-struct hook_functions {
-    virtual ~hook_functions() {};
-
-};
-
-struct mock_functions : hook_functions {
-
-} *mock_ptr;
-
 extern "C" {
 #include "../agent.c"
 
 }
 
+struct hook_functions {
+    virtual ~hook_functions() {};
+
+    virtual void exit( int ) = 0;
+    virtual int pthread_create(pthread_t*, const pthread_attr_t*, void*(*)(void*), void* ) = 0;
+    virtual int pthread_mutex_init(pthread_mutex_t*, const pthread_mutexattr_t * ) = 0;
+    virtual int pthread_cond_init(pthread_cond_t*, const pthread_condattr_t*) = 0;
+    virtual FILE* fopen(const char *, const char *) = 0;
+    virtual int write( int, void*, int ) = 0;
+    virtual int read( int, void*, int ) = 0;
+
+    virtual void agent_cleanup( void ) = 0;
+    virtual ssize_t as_write( int, void*, size_t ) = 0;
+    virtual ssize_t as_read( int, void*, size_t ) = 0;
+    virtual MBA_AGENT_RETURN import_host_file( void ) = 0;
+    virtual MBA_AGENT_RETURN export_guest_file( void ) = 0;
+    virtual MBA_AGENT_RETURN execute_guest_cmd_return( void ) = 0;
+    virtual MBA_AGENT_RETURN execute_guest_cmd_noreturn( void ) = 0;
+    virtual MBA_AGENT_RETURN export_agent_log( void ) = 0;
+    virtual int connect_agent_server( void ) = 0;
+    virtual bool agent_is_ready( void ) = 0;
+    virtual bool agent_is_exec( void ) = 0;
+    virtual void agent_printf( const char*, ... ) = 0;
+    virtual MBA_AGENT_RETURN agent_import( const char*, const char* ) = 0;
+    virtual MBA_AGENT_RETURN agent_export( const char*, const char* ) = 0;
+    virtual MBA_AGENT_RETURN agent_execute( const char* ) = 0;
+    virtual MBA_AGENT_RETURN agent_invoke( const char* ) = 0;
+    virtual MBA_AGENT_RETURN agent_logfile( const char* ) = 0;
+    virtual MBA_AGENT_RETURN agent_init( Monitor*, uint16_t ) = 0;
+};
+
+struct mock_functions : hook_functions {
+    MOCK_METHOD1( exit, void( int ) )
+    MOCK_METHOD4( pthread_create, int(pthread_t*, const pthread_attr_t*, void*(*)(void*), void* ) )
+    MOCK_METHOD2( fopen, FILE*(const char *, const char *) )
+    MOCK_METHOD3( write, int(int, void*, int) )
+    MOCK_METHOD3( read, int(int, void*, int) )
+
+    MOCK_METHOD0( agent_cleanup, void( void ) )
+    MOCK_METHOD3( as_write, ssize_t( int, void*, size_t ) )
+    MOCK_METHOD3( as_read, ssize_t( int, void*, size_t ) )
+    MOCK_METHOD0( import_host_file, MBA_AGENT_RETURN( void ) )
+    MOCK_METHOD0( export_guest_fil, MBA_AGENT_RETURN( void ) )
+    MOCK_METHOD0( execute_guest_cmd_return, MBA_AGENT_RETURN( void ) )
+    MOCK_METHOD0( execute_guest_cmd_noreturn, MBA_AGENT_RETURN( void ) )
+    MOCK_METHOD0( export_agent_log, MBA_AGENT_RETURN( void ) )
+    MOCK_METHOD0( connect_agent_server, int( void ) )
+    MOCK_METHOD0( agent_is_ready, bool( void ) )
+    MOCK_METHOD0( agent_is_exec, bool( void ) )
+    MOCK_METHOD2( agent_printf, void(const char*, ...) )
+    MOCK_METHOD2( agent_import, MBA_AGENT_RETURN( const char*, const char* ) )
+    MOCK_METHOD2( agent_export, MBA_AGENT_RETURN( const char*, const char* ) )
+    MOCK_METHOD1( agent_execute, MBA_AGENT_RETURN( const char* ) )
+    MOCK_METHOD1( agent_invoke, MBA_AGENT_RETURN( const char* ) )
+    MOCK_METHOD1( agent_logfile, MBA_AGENT_RETURN( const char* ) )
+    MOCK_METHOD2( agent_init, MBA_AGENT_RETURN( Monitor*, uint16_t ) )
+} *mock_ptr;
+
+#undef exit
+#undef pthread_create
+#undef fopen
+#undef agent_clenup
+#undef as_write
+#undef as_read
+#undef import_host_file
+#undef export_guest_file
+#undef execute_guest_cmd_return
+#undef execute_guest_cmd_noreturn
+#undef export_agent_log
+#undef connect_agent_server
+#undef agent_is_ready
+#undef agent_is_exec
+#undef agent_printf
+#undef agent_import
+#undef agent_export
+#undef agent_execute
+#undef agent_invoke
+#undef agent_logfile
+#undef agent_init
+
 #define GEN_MOCK_OBJECT( x )  mock_functions x; mock_ptr = &x;
 #define GEN_NICEMOCK_OBJECT( x )  NiceMock<mock_functions> x; mock_ptr = &x;
+
+using namespace ::testing;
+class FixtureAgentContextInitilizes : public Test {
+protected:
+    virtual void SetUp() {
+        GEN_MOCK_OBJECT( mock );
+
+        EXPECT_CALLL( mock, agent_is_ready() ).WillOnce( Return( true ) );
+        EXPECT_CALLL( mock, pthread_mutex_init(_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALLL( mock, pthread_mutex_init(_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALLL( mock, pthread_cond_init(_,_) ).WillOnce( Return( 0 ) );
+        EXPECT_CALLL( mock, pthread_create(_,_,_,_) ).WillOnce( Return( 0 ) );
+
+        _agent_init(NULL, 8888);
+
+    }
+    virtual void TearDown() {
+        // No recycable due to all initializations mocked
+    }
+}
+
+// Static Functions Testing
+TEST ( Agent_Init, WRITE_FAIL ) {
+    GEN_MOCK_OBJECT( mock );
+    
+    EXPECT_CALL( mock, write(_,_,_) ).WillOnce( Return(-1) );
+    EXPECT_CALL( mock, agent_printf("The connection to the agent server is broken while reading\n") ).Times( 1 )
+    EXPECT_CALL( mock, agent_clenup() ).Times( 1 );
+
+    _agent_init();
+}
+
+
+
+
 

--- a/ext/agent/test/test.h
+++ b/ext/agent/test/test.h
@@ -1,0 +1,27 @@
+// Library functions
+#define exit(x) mock_ptr->(x)
+#define pthread_create(x, y, z, a) mock_ptr->pthread_create(x, y, z, a)
+#define fopen(x, y) mock_ptr->fopen(x, y)
+#define write(x, y, z) mock_ptr->write(x, y, z)
+#define read(x, y, z) mock_ptr->read(x, y, z)
+
+// Static functions
+#define agent_cleanup() mock_ptr->agent_cleanup()
+#define as_write(x, y, z) mock_ptr->as_write(x, y, z)
+#define as_read(x, y, z) mock_ptr->as_read(x, y, z)
+#define import_host_file() mock_ptr->import_host_file()
+#define export_guest_file() mock_ptr->export_guest_file()
+#define execute_guest_cmd_return() mock_ptr->execute_guest_cmd_return()
+#define execute_guest_cmd_noreturn() mock_ptr->execute_guest_cmd_noreturn()
+#define export_agent_log() mock_ptr->export_agent_log()
+#define connect_agent_server() mock_ptr->connect_agent_server()
+
+// Public API
+#define agent_is_ready() mock_ptr->agent_is_ready()
+#define agent_is_exec() mock_ptr->agent_is_exec()
+#define agent_import(x, y) mock_ptr->agent_import(x, y)
+#define agent_export(x, y) mock_ptr->agent_export(x, y)
+#define agent_execute(x) mock_ptr->agent_execute(x)
+#define agent_invoke(x) mock_ptr->agent_invoke(x)
+#define agent_logfile(x) mock_ptr->agent_logfile(x)
+#define agent_init(x, y) mock_ptr->agent_init(x, y)

--- a/ext/agent/test/test.h
+++ b/ext/agent/test/test.h
@@ -1,5 +1,5 @@
 // Library functions
-#define exit(x) mock_ptr->(x)
+#define exit(x) mock_ptr->exit(x)
 #define pthread_create(x, y, z, a) mock_ptr->pthread_create(x, y, z, a)
 #define fopen(x, y) mock_ptr->fopen(x, y)
 #define write(x, y, z) mock_ptr->write(x, y, z)
@@ -13,10 +13,12 @@
 #define export_guest_file() mock_ptr->export_guest_file()
 #define execute_guest_cmd_return() mock_ptr->execute_guest_cmd_return()
 #define execute_guest_cmd_noreturn() mock_ptr->execute_guest_cmd_noreturn()
+#define sync_cache() mock_ptr->sync_cache()
 #define export_agent_log() mock_ptr->export_agent_log()
 #define connect_agent_server() mock_ptr->connect_agent_server()
 
 // Public API
+#define agent_printf(x, ...) mock_ptr->agent_printf(x)
 #define agent_is_ready() mock_ptr->agent_is_ready()
 #define agent_is_exec() mock_ptr->agent_is_exec()
 #define agent_import(x, y) mock_ptr->agent_import(x, y)
@@ -24,4 +26,5 @@
 #define agent_execute(x) mock_ptr->agent_execute(x)
 #define agent_invoke(x) mock_ptr->agent_invoke(x)
 #define agent_logfile(x) mock_ptr->agent_logfile(x)
-#define agent_init(x, y) mock_ptr->agent_init(x, y)
+#define agent_sync() mock_ptr->agent_sync()
+#define agent_init(x, y, z) mock_ptr->agent_init(x, y, z)

--- a/ext/agent/windows/win_agent.c
+++ b/ext/agent/windows/win_agent.c
@@ -38,6 +38,8 @@
 static BOOL   g_bRunThread = TRUE;          // Boolean valuable, True for writing to child
 static SOCKET g_sClientSocket;              // Socket for connecting, writing, and reading in different function
 static SOCKET g_sClientDupSocket;           // Duplicate client socket for execute_cmd
+static struct sockaddr_in clientaddr;
+static int    slen;
 
 // Log file
 static SYSTEMTIME localTime;                // Local system time
@@ -46,6 +48,7 @@ static char   g_sLogPath[MAX_PATH];         // Log fullpath name
 static char   g_sLogMessage[SZ_MAX_LOG];    // Log message
 static char   g_sLogTime[SZ_MAX_LOG];       // Message of local time
 static DWORD  g_dwBytesWritten;             // Used for function 'write_log' to store string length
+NTSTATUS (WINAPI *NtSetSystemInformation)(INT, PVOID, ULONG);
 
 /// Write system time and log message to log file.
 ///
@@ -106,7 +109,7 @@ static void display_error(char *pszAPI, bool socket_send)
     write_log();
 
     if (socket_send)
-        send(g_sClientSocket, (char *)szPrintBuffer, lstrlen((LPSTR)(szPrintBuffer)), 0);
+        sendto(g_sClientSocket, (char *)szPrintBuffer, lstrlen((LPSTR)(szPrintBuffer)), 0, (struct sockaddr*)&clientaddr, slen);
 
     LocalFree(lpvMessageBuffer);
 }
@@ -128,6 +131,8 @@ static int identify_command(char input[SZ_MAX_CMD])
         return MBA_CMD_IMPO;
     else if (strncmp(input, "logf", 4)==0)
         return MBA_CMD_LOGF;
+    else if (strncmp(input, "sync", 4)==0)
+        return MBA_CMD_SYNC;
         
     return MBA_CMD_UNKNOWN;
 }
@@ -153,7 +158,7 @@ static DWORD WINAPI get_and_send_input_thread(LPVOID lpvThreadParam)
     ///      2. The main thread detects child process termination and close the DUPLICATED socket,
     ///         causing the recv failed with return <= 0
     while( TRUE ) {
-        nBytesRead = recv(g_sClientDupSocket, cInBuf, SZ_MAX_CMD, MSG_WAITALL);
+        nBytesRead = recvfrom(g_sClientDupSocket, cInBuf, SZ_MAX_CMD, 0, (struct sockaddr*)&clientaddr, &slen);
         if( nBytesRead > 0 ) {
 
             if( !WriteFile(hPipeWrite, cInBuf, strlen(cInBuf), &nBytesWrote, NULL) ) {
@@ -182,7 +187,7 @@ static void read_and_handle_output(HANDLE hPipeRead)
     DWORD nBytesRead;
 
     // send ready message for agent 'execute' action
-    send( g_sClientSocket, MSG_EXEC_READY, sizeof(MSG_EXEC_READY), 0 );
+    sendto( g_sClientSocket, MSG_EXEC_READY, sizeof(MSG_EXEC_READY), 0, (struct sockaddr*)&clientaddr, slen);
     display_error("MSG_EXEC_READY - Sent", FALSE);
 
     while (TRUE) {
@@ -198,8 +203,8 @@ static void read_and_handle_output(HANDLE hPipeRead)
                 display_error("read_and_handle_output - ReadFile", TRUE);
         }
 
-        send(g_sClientSocket, (const char*)&nBytesRead, sizeof(nBytesRead), 0);
-        send(g_sClientSocket, cOutBuf, nBytesRead, 0);
+        sendto(g_sClientSocket, (const char*)&nBytesRead, sizeof(nBytesRead), 0, (struct sockaddr*)&clientaddr, slen);
+        sendto(g_sClientSocket, cOutBuf, nBytesRead, 0, (struct sockaddr*)&clientaddr, slen);
         
     }
 }
@@ -354,7 +359,7 @@ static MBA_AGENT_RETURN execute_cmd(char *sCmdline) {
     closesocket( g_sClientDupSocket );
     
     // send out the zero-sized message to terminate agent 'exec' action
-    send(g_sClientSocket, (const char*)&dEndSize, sizeof(dEndSize), 0);
+    sendto(g_sClientSocket, (const char*)&dEndSize, sizeof(dEndSize), 0, (struct sockaddr*)&clientaddr, slen);
 
     // Wait Thread which keep receiving & forwarding commands
     if (WaitForSingleObject(hThread, INFINITE) == WAIT_FAILED) {
@@ -386,11 +391,11 @@ static MBA_AGENT_RETURN invoke_cmd(char *sCmdline) {
     ZeroMemory(&pi, sizeof(pi));
 
     if ( CreateProcess(NULL, sCmdline, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi) == TRUE ) {
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
         return AGENT_RET_SUCCESS;
     }
     else {
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         return AGENT_RET_FAIL;
     }
 }
@@ -419,7 +424,7 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
     char errorbuf[sizeof(MSG_REC_SUCCESS)];
     
     // Get total file size messege from client
-    nBytesRead = recv( g_sClientSocket, (char*)&fileSize, sizeof(fileSize), MSG_WAITALL );
+    nBytesRead = recvfrom( g_sClientSocket, (char*)&fileSize, sizeof(fileSize), 0, (struct sockaddr*)&clientaddr, &slen );
     if ( nBytesRead != sizeof(fileSize) ) {
         display_error("import_cmd - Receive - can't receive fileszie", FALSE);
         return AGENT_RET_FAIL;
@@ -442,11 +447,11 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
 
     if (g_hLog == INVALID_HANDLE_VALUE) {
         display_error("import_cmd - CreateFile - can't open file", FALSE);
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         return AGENT_RET_FAIL;
     }
     else
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
     
     // caculate how many rounds to receive the file content;
     recvRound = fileSize / SZ_MAX_FILECHUNK;
@@ -455,7 +460,7 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
     while (recvRound) {
 
         // --------Check client can read file successfully-------- //
-        nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+        nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
         if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
             display_error("import_cmd - CheckClient - can't check client read file successfully", FALSE);
             CloseHandle(hFile);
@@ -468,7 +473,7 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
         }
     
         // Receive file contents
-        nBytesRead = recv( g_sClientSocket, fBuf, SZ_MAX_FILECHUNK, MSG_WAITALL );
+        nBytesRead = recvfrom( g_sClientSocket, fBuf, SZ_MAX_FILECHUNK, 0, (struct sockaddr*)&clientaddr, &slen );
         if( nBytesRead != SZ_MAX_FILECHUNK ) {
             display_error("import_cmd - recv", TRUE);
             CloseHandle(hFile);
@@ -478,12 +483,12 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
         // Write file contents
         if( WriteFile( hFile, fBuf, nBytesRead, (LPDWORD)&nBytesWrite, NULL ) == FALSE ) {
             display_error("import_cmd - WriteFile", FALSE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             CloseHandle(hFile);
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
 
         sprintf_s(g_sLogMessage, SZ_MAX_LOG, "read %ld bytes, fwrite %ld bytes\r\n", nBytesRead, nBytesWrite);
         write_log();
@@ -498,7 +503,7 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
     if( nBytesRead ) {
         
         // --------Check client can read file successfully-------- //
-        nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+        nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
         if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
             display_error("import_cmd - CheckClient - can't check client read file successfully", FALSE);
             CloseHandle(hFile);
@@ -511,7 +516,7 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
         }
     
         ZeroMemory( fBuf, SZ_MAX_FILECHUNK );
-        if( nBytesRead != recv( g_sClientSocket, fBuf, nBytesRead, 0 ) ) {
+        if( nBytesRead != recvfrom( g_sClientSocket, fBuf, nBytesRead, 0, (struct sockaddr*)&clientaddr, &slen ) ) {
             display_error("import_cmd - recv", TRUE);
             CloseHandle(hFile);
             return AGENT_RET_FAIL;
@@ -521,12 +526,12 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
         // Write file contents
         if( WriteFile(hFile, fBuf, SZ_MAX_FILECHUNK, (LPDWORD)&nBytesWrite, NULL) == FALSE ) {
             display_error("import_cmd - WriteFile", TRUE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             CloseHandle(hFile);
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
 
         fileSizeStored += nBytesRead;
 
@@ -538,12 +543,12 @@ static MBA_AGENT_RETURN import_cmd(char *filePath)
         // Set file pointer 
         ptrSetFile = SetFilePointer( hFile, fileSizeStored, NULL, FILE_BEGIN );
         if ( ptrSetFile ==  INVALID_SET_FILE_POINTER ) {
-            display_error("export_log - GetFileSizeEx", FALSE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            display_error("expolog_cmd - GetFileSizeEx", FALSE);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
         SetEndOfFile( hFile );
     }
     
@@ -589,23 +594,23 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
         
     if (hFile == INVALID_HANDLE_VALUE) {
         display_error("export_cmd - CreateFile", TRUE);
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         return AGENT_RET_FAIL;
     }
     else
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
     
     // Get file size
     if (!GetFileSizeEx(hFile, &fileSize)) {
         display_error("export_cmd - GetFileSizeEx", TRUE);
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         CloseHandle(hFile);
         return AGENT_RET_FAIL;
     }
     else
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
             
-    // Show information and send file size to client
+    // Show information and sendto file size to client
     sprintf_s(g_sLogMessage, SZ_MAX_LOG, "filePath:[%s]\r\n", filePath);
     write_log();
 
@@ -613,15 +618,15 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
     write_log();
     
     // Send file size
-    nBytesWrite = send(g_sClientSocket, (const char*)&fileSize.QuadPart, sizeof(fileSize.QuadPart), 0);
+    nBytesWrite = sendto(g_sClientSocket, (const char*)&fileSize.QuadPart, sizeof(fileSize.QuadPart), 0, (struct sockaddr*)&clientaddr, slen);
     if( nBytesWrite != sizeof(fileSize.QuadPart) ) {
-        display_error("export_cmd - send", TRUE);
+        display_error("export_cmd - sendto", TRUE);
         CloseHandle(hFile);
         return AGENT_RET_FAIL;
     }
 
     // --------Check if client can open file successfully-------- //
-    nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+    nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
     if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
         display_error("export_cmd - CheckClient - can't check client open file successfully", FALSE);
         CloseHandle(hFile);
@@ -633,7 +638,7 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
         return AGENT_RET_FAIL;
     }
     
-    // calculate how many rounds to send file content
+    // calculate how many rounds to sendto file content
     sendRound = fileSize.QuadPart / SZ_MAX_FILECHUNK;
 
     // start to deliver the file content to QEMU
@@ -643,23 +648,23 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
         // Read file contents
         if( ReadFile(hFile, fBuf, SZ_MAX_FILECHUNK, (LPDWORD)&nBytesRead, NULL) == 0 ) {
             display_error( "export_cmd - ReadFile", TRUE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
         
         // Send file contents
-        nBytesWriteOneTime = send(g_sClientSocket, fBuf, nBytesRead, 0);
+        nBytesWriteOneTime = sendto(g_sClientSocket, fBuf, nBytesRead, 0, (struct sockaddr*)&clientaddr, slen);
         if ( nBytesWriteOneTime != nBytesRead ){
-            display_error("export_cmd - CheckClient - can't send file successfully", FALSE);
+            display_error("export_cmd - CheckClient - can't sendto file successfully", FALSE);
             CloseHandle(hFile);
             return AGENT_RET_FAIL;
         }
             nBytesWrite += nBytesWriteOneTime;
         
         // --------Check if client can write file successfully-------- //
-        nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+        nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
         if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
             display_error("export_cmd - CheckClient - can't check client write file successfully", FALSE);
             CloseHandle(hFile);
@@ -678,7 +683,7 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
     }
     CloseHandle(hFile);
 
-    // send the remaining file content
+    // sendto the remaining file content
     nBytesRead = fileSize.QuadPart % SZ_MAX_FILECHUNK;
     if( nBytesRead ) {
 
@@ -694,11 +699,11 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
 
         if(hFile == INVALID_HANDLE_VALUE) {
             display_error( "export_cmd - CreateFile", TRUE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
 
         // move the file pointer to the last-read position
         SetFilePointer(hFile, nBytesWrite, NULL, FILE_BEGIN);
@@ -706,24 +711,24 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
         // read the remaining file content
         if( ReadFile(hFile, fBuf, nBytesRead, (LPDWORD)&nBytesRead, NULL) == 0 ) {
             display_error("export_cmd - ReadFile", TRUE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             CloseHandle(hFile);
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
         
-        // send the content
-        nBytesWriteOneTime = send(g_sClientSocket, fBuf, nBytesRead, 0);
+        // sendto the content
+        nBytesWriteOneTime = sendto(g_sClientSocket, fBuf, nBytesRead, 0, (struct sockaddr*)&clientaddr, slen);
         if ( nBytesWriteOneTime != nBytesRead ){
-            display_error("export_cmd - CheckClient - can't send file successfully", FALSE);
+            display_error("export_cmd - CheckClient - can't sendto file successfully", FALSE);
             CloseHandle(hFile);
             return AGENT_RET_FAIL;
         }
             nBytesWrite += nBytesWriteOneTime;
 
         // --------Check if client can write file successfully-------- //
-        nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+        nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
         if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
             display_error("export_cmd - CheckClient - can't check client write file successfully", FALSE);
             CloseHandle(hFile);
@@ -738,7 +743,7 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
         CloseHandle(hFile);
     }
  
-    sprintf_s(g_sLogMessage, SZ_MAX_LOG, "File size: %ld bytes, Total send: %ld bytes\r\n", fileSize.QuadPart, nBytesWrite);
+    sprintf_s(g_sLogMessage, SZ_MAX_LOG, "File size: %ld bytes, Total sendto: %ld bytes\r\n", fileSize.QuadPart, nBytesWrite);
     write_log();
 
     return AGENT_RET_SUCCESS;
@@ -747,7 +752,7 @@ static MBA_AGENT_RETURN export_cmd(char *filePath)
 /// Do 'logf' instruction.
 /// 
 /// Return AGENT_RET_SUCCESS if succeed, or AGENT_RET_FAIL if fail
-static MBA_AGENT_RETURN export_log( void )
+static MBA_AGENT_RETURN expolog_cmd( void )
 {
     LARGE_INTEGER fileSize;
     
@@ -762,6 +767,8 @@ static MBA_AGENT_RETURN export_log( void )
     
     char fBuf[SZ_MAX_FILECHUNK];   // export buffer
     char errorbuf[sizeof(MSG_REC_SUCCESS)];
+	
+	struct sockaddr_in clientaddr;
     
     // Duplicate the global log handle and check the result
     if ( !DuplicateHandle( 
@@ -772,43 +779,43 @@ static MBA_AGENT_RETURN export_log( void )
           0,
           FALSE,
           DUPLICATE_SAME_ACCESS ) ) {
-        display_error("export_log - GetFileSizeEx", FALSE);
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        display_error("expolog_cmd - GetFileSizeEx", FALSE);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         return AGENT_RET_FAIL;
     }
     else
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
     
     // Set the file pointer of hLog and check the result
     ptrSetFile = SetFilePointer(hLog, 0, NULL, FILE_BEGIN);
     if ( ptrSetFile ==  INVALID_SET_FILE_POINTER ) {
-        display_error("export_log - GetFileSizeEx", FALSE);
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        display_error("expolog_cmd - GetFileSizeEx", FALSE);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         return AGENT_RET_FAIL;
     }
     else
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
     
     // Read log file size
     if (!GetFileSizeEx(hLog, &fileSize)) {
-        display_error("export_log - GetFileSizeEx", FALSE);
-        send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+        display_error("expolog_cmd - GetFileSizeEx", FALSE);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
         CloseHandle( hLog );
         return AGENT_RET_FAIL;
     }
     else
-        send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+        sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
     
     // Send log file size
-    nBytesWrite = send(g_sClientSocket, (const char*)&fileSize.QuadPart, sizeof(fileSize.QuadPart), 0);
+    nBytesWrite = sendto(g_sClientSocket, (const char*)&fileSize.QuadPart, sizeof(fileSize.QuadPart), 0, (struct sockaddr*)&clientaddr, slen);
     if( nBytesWrite != sizeof(fileSize.QuadPart) ) {
-        display_error("export_log - send", TRUE);
+        display_error("expolog_cmd - send", TRUE);
         CloseHandle( hLog );
         return AGENT_RET_FAIL;
     }
     
     // --------Check if client can open file successfully-------- //
-    nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+    nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
     if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
         display_error("export_cmd - CheckClient - can't check client open file successfully", FALSE);
         CloseHandle( hLog );
@@ -829,16 +836,16 @@ static MBA_AGENT_RETURN export_log( void )
 
         // Read log file contents
         if( ReadFile(hLog, fBuf, SZ_MAX_FILECHUNK, (LPDWORD)&nBytesRead, NULL) == 0 ) {
-            display_error( "export_log - ReadFile", TRUE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            display_error( "expolog_cmd - ReadFile", TRUE);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             CloseHandle( hLog );
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
             
         // send the contents
-        nBytesWriteOneTime = send(g_sClientSocket, fBuf, nBytesRead, 0);
+        nBytesWriteOneTime = sendto(g_sClientSocket, fBuf, nBytesRead, 0, (struct sockaddr*)&clientaddr, slen);
         if ( nBytesWriteOneTime != nBytesRead ){
             display_error("export_cmd - CheckClient - can't send file successfully", FALSE);
             CloseHandle( hLog );
@@ -847,7 +854,7 @@ static MBA_AGENT_RETURN export_log( void )
         nBytesWrite += nBytesWriteOneTime;
         
         // --------Check if client can write file successfully-------- //
-        nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+        nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
         if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
             display_error("export_cmd - CheckClient - can't check client write file successfully", FALSE);
             CloseHandle( hLog );
@@ -871,16 +878,16 @@ static MBA_AGENT_RETURN export_log( void )
 
         // read the remaining file contents
         if( ReadFile(hLog, fBuf, nBytesRead, (LPDWORD)&nBytesRead, NULL) == 0 ) {
-            display_error("export_log - ReadFile", TRUE);
-            send(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0);
+            display_error("expolog_cmd - ReadFile", TRUE);
+            sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
             CloseHandle( hLog );
             return AGENT_RET_FAIL;
         }
         else
-            send(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0);
+            sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
         
         // send the contents
-        nBytesWriteOneTime = send(g_sClientSocket, fBuf, nBytesRead, 0);
+        nBytesWriteOneTime = sendto(g_sClientSocket, fBuf, nBytesRead, 0, (struct sockaddr*)&clientaddr, slen);
         if ( nBytesWriteOneTime != nBytesRead ){
             display_error("export_cmd - CheckClient - can't send file successfully", FALSE);
             CloseHandle( hLog );
@@ -889,7 +896,7 @@ static MBA_AGENT_RETURN export_log( void )
         nBytesWrite += nBytesWriteOneTime;
         
         // --------Check if client can write file successfully-------- //
-        nErrorBytesRead = recv( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), MSG_WAITALL );
+        nErrorBytesRead = recvfrom( g_sClientSocket, errorbuf, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, &slen );
         if ( nErrorBytesRead != sizeof(MSG_REC_SUCCESS) ) {
             display_error("export_cmd - CheckClient - can't check client write file successfully", FALSE);
             CloseHandle( hLog );
@@ -908,7 +915,48 @@ static MBA_AGENT_RETURN export_log( void )
     return AGENT_RET_SUCCESS;
 }
 
-void server_mainloop( SOCKET sListenSocket ) 
+/// Do 'sync' instruction.
+/// 
+/// Return AGENT_RET_SUCCESS if succeed, or AGENT_RET_FAIL if fail
+static MBA_AGENT_RETURN sync_cmd( void )
+{
+	// file buffer flush
+	int sysinfo = 4,
+	    retVal;
+	HANDLE hVol;
+	
+	hVol = CreateFile(  "\\\\.\\C:",
+	           	        GENERIC_READ | GENERIC_WRITE,
+						FILE_SHARE_READ | FILE_SHARE_WRITE,
+	                    NULL, 
+						OPEN_EXISTING, 
+						0,
+						NULL );
+						
+	if ( hVol == INVALID_HANDLE_VALUE ){
+		display_error("expolog_cmd - [COMMAND ERROR] Flush Openfile Error", FALSE);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
+        return AGENT_RET_FAIL;
+	}
+	else
+		sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
+	
+	retVal = FlushFileBuffers( hVol );
+	if( retVal == 0 ){
+        display_error("expolog_cmd - [COMMAND ERROR] Flush Openfile Error", FALSE);
+        sendto(g_sClientSocket, MSG_REC_FAIL, sizeof(MSG_REC_FAIL), 0, (struct sockaddr*)&clientaddr, slen);
+        return AGENT_RET_FAIL;
+	}
+	else
+	    sendto(g_sClientSocket, MSG_REC_SUCCESS, sizeof(MSG_REC_SUCCESS), 0, (struct sockaddr*)&clientaddr, slen);
+	
+	CloseHandle( hVol );
+	NtSetSystemInformation( 80, &sysinfo, sizeof(sysinfo)) ;
+	
+    return AGENT_RET_SUCCESS;
+}
+
+void server_mainloop( SOCKET server_socket ) 
 {
     SOCKET sClientSocket;
     
@@ -924,22 +972,26 @@ void server_mainloop( SOCKET sListenSocket )
     while( true ) {
         
         // Accept a client socket
+		/*
         sClientSocket = accept(sListenSocket, NULL, NULL);
         if (sClientSocket == INVALID_SOCKET) {
             display_error("main - accept", FALSE);
             break;
         }
-		
-        g_sClientSocket = sClientSocket;
+		*/
+        g_sClientSocket = server_socket;
 
-        sprintf_s(g_sLogMessage, SZ_MAX_LOG, "[SYSTEM] Connection starting...\r\n");
+        sprintf_s(g_sLogMessage, SZ_MAX_LOG, "[SYSTEM] Start to get commands...\r\n");
         write_log();
         
+		slen = sizeof(clientaddr);
+
         // Receive until the peer shuts down the connection
         do {
             
             ZeroMemory(sRecvbuf, sizeof(sRecvbuf));
-            iResult = recv(sClientSocket, sRecvbuf, SZ_MAX_CMD, MSG_WAITALL);
+			
+            iResult = recvfrom(server_socket, sRecvbuf, SZ_MAX_CMD, 0, (struct sockaddr *)&clientaddr, &slen);
             
             if (iResult > 0) {
             
@@ -972,7 +1024,11 @@ void server_mainloop( SOCKET sListenSocket )
                         break;
 
                     case MBA_CMD_LOGF :
-                        command_result = export_log();
+                        command_result = expolog_cmd();
+                        break;
+						
+                    case MBA_CMD_SYNC :
+                        command_result = sync_cmd();
                         break;
 
                     case MBA_CMD_UNKNOWN :
@@ -985,15 +1041,15 @@ void server_mainloop( SOCKET sListenSocket )
                 if ( command_result == AGENT_RET_SUCCESS ) {
                 
                     // Echo the buffer back to the sender
-                    iSendResult = send(sClientSocket, MSG_ACK_PREFIX, sizeof(MSG_ACK_PREFIX), 0);
+                    iSendResult = sendto(server_socket, MSG_ACK_PREFIX, sizeof(MSG_ACK_PREFIX), 0, (struct sockaddr *)&clientaddr, slen);
                     if (iSendResult == SOCKET_ERROR) {
-                        display_error("main - Send to sClientSocket", FALSE);
+                        display_error("main - Send to server_socket", FALSE);
                         break;
                     }
                             
-                    iSendResult = send(sClientSocket, sRecvbuf, SZ_MAX_CMD, 0);
+                    iSendResult = sendto(server_socket, sRecvbuf, SZ_MAX_CMD, 0, (struct sockaddr *)&clientaddr, slen);
                     if (iSendResult == SOCKET_ERROR) {
-                        display_error("main - Send to sClientSocket", FALSE);
+                        display_error("main - Send to server_socket", FALSE);
                         break;
                     }
                 }
@@ -1006,18 +1062,18 @@ void server_mainloop( SOCKET sListenSocket )
             else if (GetLastError() == 0)
                 break;
             else {
-                display_error("Receive from sClientSocket", FALSE);
+                display_error("Receive from server_socket", FALSE);
                 break;
             }
         } while (iResult > 0);
 		
         // shutdown the connection since we're done
-        iResult = shutdown(sClientSocket, SD_SEND);
+        iResult = shutdown(server_socket, SD_SEND);
         if (iResult != -1 && iResult == SOCKET_ERROR) {
-            closesocket(sClientSocket);
-            display_error("Main - shutdown sClientSocket", FALSE);
+            closesocket(server_socket);
+            display_error("Main - shutdown server_socket", FALSE);
         }
-        closesocket(sClientSocket);
+        closesocket(server_socket);
         sprintf_s(g_sLogMessage, SZ_MAX_LOG, "[SYSTEM] Connection closing...\r\n");
         write_log();  
     }
@@ -1031,19 +1087,27 @@ void server_mainloop( SOCKET sListenSocket )
 /// Return -1 for socket error, program should be terminate
 static SOCKET socket_setup()
 {
+    SOCKET server_socket;
+	
     int iResult;            // system information with error message
+	
     char host_name[128];    // host name
     SOCKET sListenSocket;
 
     struct addrinfo hints;
     struct addrinfo *result = NULL;
+    struct addrinfo *ptr = NULL;
 
     // Initial socket information
     ZeroMemory(&hints, sizeof(hints));
-    hints.ai_family = AF_INET;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = IPPROTO_TCP;
     hints.ai_flags = AI_PASSIVE;
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    hints.ai_canonname = NULL;
+    hints.ai_addr = NULL;
+    hints.ai_next = NULL;
+    hints.ai_addrlen = 0;
 
     // Resolve the server address and port
     gethostname(host_name, sizeof(host_name));
@@ -1057,26 +1121,25 @@ static SOCKET socket_setup()
     }
 
     // Create a SOCKET for connecting to server
-    sListenSocket = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
-    if (sListenSocket == INVALID_SOCKET) {
+    server_socket = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+    if (server_socket == INVALID_SOCKET) {
         freeaddrinfo(result);
         WSACleanup();
         display_error("main - socket", FALSE);
         return -1;
     }
 
-    // Setup the TCP listening socket
-    iResult = bind(sListenSocket, result->ai_addr, (int)result->ai_addrlen);
+    iResult = bind(server_socket, result->ai_addr, (int)result->ai_addrlen);
     if (iResult == SOCKET_ERROR) {
-        freeaddrinfo(result);
-        closesocket(sListenSocket);
-        WSACleanup();
         display_error("main - bind", FALSE);
+        freeaddrinfo(result);
+        closesocket(server_socket);
+        WSACleanup();
         return -1;
     }
 
     freeaddrinfo(result);
-    
+    /*
     iResult = listen(sListenSocket, SOMAXCONN);
     if (iResult == SOCKET_ERROR) {
         closesocket(sListenSocket);
@@ -1084,10 +1147,10 @@ static SOCKET socket_setup()
         display_error("main - listen", FALSE);
         return -1;
     }
+    */
+    return server_socket;
 
-    return sListenSocket;
 }
-
 
 HANDLE create_log_file( const char* logPath ) 
 {    
@@ -1126,11 +1189,33 @@ int __cdecl main( int argc, char* argv[] )
     ShowWindow(GetConsoleWindow(),SW_HIDE);
     
     int iResult;
-    
+	
     WSADATA wsaData;
     SOCKET sListenSocket = INVALID_SOCKET;  // listen socket
     
-    GetLocalTime(&localTime);
+    LUID pv;
+	TOKEN_PRIVILEGES tp;
+	HANDLE hProc;
+	HMODULE ntdll;
+	
+	// Raise up the privilege
+	LookupPrivilegeValue( NULL, "SeProfileSingleProcessPrivilege", &pv );
+	OpenProcessToken( GetCurrentProcess(), TOKEN_WRITE, &hProc );
+		
+	tp.PrivilegeCount			= 1;
+	tp.Privileges[0].Luid		= pv;
+	tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+	AdjustTokenPrivileges(	hProc,
+							FALSE,
+							&tp,
+							sizeof(TOKEN_PRIVILEGES),
+							(PTOKEN_PRIVILEGES)NULL,
+							(PDWORD)NULL );
+	ntdll = LoadLibrary("ntdll.dll");
+	NtSetSystemInformation = (NTSTATUS (WINAPI *)(INT, PVOID, ULONG))GetProcAddress(ntdll, "NtSetSystemInformation");	
+	
+	GetLocalTime(&localTime);
     
     g_hLog = create_log_file( NULL );
     if (g_hLog == INVALID_HANDLE_VALUE) {

--- a/ext/agent/windows/win_agent.h
+++ b/ext/agent/windows/win_agent.h
@@ -5,7 +5,7 @@
  *
  *  Copyright (c)   2016 E-lin Ho
  *                  2016 Chiawei Wang
- *                  2016 JuiChien, Jao
+ *                  2016 Juichien Jao
  *                  
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -44,7 +44,8 @@ enum cmd_type {
     MBA_CMD_INVO,       // 2 : Command begging with 'invo' from MBA     // invoke
     MBA_CMD_EXPO,       // 3 : Command begging with 'expo' from MBA     // export
     MBA_CMD_IMPO,       // 4 : Command begging with 'impo' from MBA     // import
-    MBA_CMD_LOGF        // 5 : Command begging with 'logf' from MBA     // log file
+    MBA_CMD_LOGF,        // 5 : Command begging with 'logf' from MBA     // log file
+    MBA_CMD_SYNC        // 6 : Command begging with 'sync' from MBA     // sync
 };
 
 //common return value


### PR DESCRIPTION
1. Change the protocol between agent client and agent server from TCP to UDP.
2. Enable to connect to the agent server in snapshot.
    2-1. Use parameter "fwd_port_in" of "agent_init" function to distinguish agent initialization from agent reset.
3. Add w_sync command.
4. Move the code of port redirection from /ext/agent/agent_commands.c to ext/agent/agent.c
    4-1. "agent_init" function modified.
    4-2. Use function pointer to deal with the link error of "net_slirp_redir" function.
5. Add w_sync functions' declarations to ext/agent/test/test.h and ext/agent/test/agetn_unittest.cc
6. Add comments to modifications.