### PR TITLE
Enhance agent asynchronization safety

### DIFF
--- a/ext/agent/agent-commands.c
+++ b/ext/agent/agent-commands.c
@@ -24,8 +24,7 @@
 #include "agent-commands.h"
 #include "agent.h"
 
-void do_win_impo( Monitor *mon, const QDict *qdict ) 
-{
+void do_win_impo( Monitor *mon, const QDict *qdict )  {
 
     MBA_AGENT_RETURN ret;
 
@@ -57,8 +56,7 @@ void do_win_impo( Monitor *mon, const QDict *qdict )
     }
 }
 
-void do_win_expo( Monitor *mon, const QDict *qdict ) 
-{
+void do_win_expo( Monitor *mon, const QDict *qdict )  {
 
     MBA_AGENT_RETURN ret;
 
@@ -90,8 +88,7 @@ void do_win_expo( Monitor *mon, const QDict *qdict )
     }
 }
 
-void do_win_exec( Monitor *mon, const QDict *qdict )
-{
+void do_win_exec( Monitor *mon, const QDict *qdict ) {
     MBA_AGENT_RETURN ret;
 
     char* cmdline = (char*)qdict_get_str(qdict, "cmdline");
@@ -121,8 +118,7 @@ void do_win_exec( Monitor *mon, const QDict *qdict )
     }   
 }
 
-void do_win_invo( Monitor *mon, const QDict *qdict )
-{
+void do_win_invo( Monitor *mon, const QDict *qdict ) {
     MBA_AGENT_RETURN ret;
 
     char* cmdline = (char*)qdict_get_str(qdict, "cmdline");
@@ -153,8 +149,7 @@ void do_win_invo( Monitor *mon, const QDict *qdict )
 
 }
 
-void do_win_logf( Monitor *mon, const QDict *qdict )
-{
+void do_win_logf( Monitor *mon, const QDict *qdict ) {
     MBA_AGENT_RETURN ret;
 
     char* dst_path = (char*)qdict_get_str(qdict, "dstpath");
@@ -184,8 +179,7 @@ void do_win_logf( Monitor *mon, const QDict *qdict )
     }   
 }
 
-void do_win_init( Monitor *mon, const QDict *qdict )
-{
+void do_win_init( Monitor *mon, const QDict *qdict ) {
     MBA_AGENT_RETURN ret;
 
     // initialize agent

--- a/ext/agent/agent.h
+++ b/ext/agent/agent.h
@@ -71,8 +71,15 @@ extern bool agent_is_ready( void );
 ///
 ///        no param
 ///
-/// Return true if ready, false otherwise
+/// Return true if in execute command mode, false otherwise
 extern bool agent_is_exec( void );
+
+/// Check if agent is currently idle
+///
+///        no param
+///
+/// Return true if idel, false otherwise
+extern bool agent_is_idle( void );
 
 /// Print out the agent extension message
 /// If a monitor of QEMU is assigned at the initialization


### PR DESCRIPTION
1. fix the condition that an agent command overwrites the previous one before it is consumed
2. add API to query if agent is idle, meaning the completion of a given command