### PR TITLE
Bugfix for the OBHook extension

### DIFF
--- a/ext/agent/agent-commands-spec.h
+++ b/ext/agent/agent-commands-spec.h
@@ -18,7 +18,7 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 {
-    .name         = "mba_winimpo",
+    .name         = "mba_wimpo",
     .args_type    = "srcpath:F,dstpath:s",
     .params       = "fullpath_host_srcfile fullpath_guest_dstfile",
     .help         = "Import a host file into the guest."
@@ -26,7 +26,7 @@
     .mhandler.cmd = do_win_impo,
 },
 {
-    .name         = "mba_winexpo",
+    .name         = "mba_wexpo",
     .args_type    = "srcpath:s,dstpath:F",
     .params       = "fullpath_guest_srcfile fullpath_host_dstfile",
     .help         = "Export a guest file to the host."
@@ -34,42 +34,42 @@
     .mhandler.cmd = do_win_expo,
 },
 {
-    .name         = "mba_winexec",
+    .name         = "mba_wexec",
     .args_type    = "cmdline:s",
     .params       = "command_to_execute",
     .help         = "Execute the given command inside the guest and perform interactive Input/Output.",
     .mhandler.cmd = do_win_exec,
 },
 {
-    .name         = "mba_wininvo",
+    .name         = "mba_winvo",
     .args_type    = "cmdline:s",
     .params       = "command_to_execute",
     .help         = "Invoke the given command inside the guest without waiting the result/output.",
     .mhandler.cmd = do_win_invo,
 },
 {
-    .name         = "mba_winlogf",
+    .name         = "mba_wlogf",
     .args_type    = "dstpath:s",
     .params       = "fullpath_logfile",
     .help         = "Export the agent log file from the guest to the host. The fullpath of the destination file is required.",
     .mhandler.cmd = do_win_logf,
 },
 {
-    .name         = "mba_wininit",
+    .name         = "mba_winit",
     .args_type    = "",
     .params       = "",
     .help         = "Create an agent thread to communicate with Windows in-VM agent server.",
     .mhandler.cmd = do_win_init,
 },
 {
-    .name         = "mba_winsync",
+    .name         = "mba_wsync",
     .args_type    = "", 
     .params       = "",
     .help         = "Flush the Guest OS cache.",
     .mhandler.cmd = do_win_sync,
 },
 {
-    .name         = "mba_winreset",
+    .name         = "mba_wrset",
     .args_type    = "", 
     .params       = "",
     .help         = "Reset the agent client to the condition before w_init.",

--- a/ext/obhook/obhook-commands.c
+++ b/ext/obhook/obhook-commands.c
@@ -50,7 +50,7 @@ void do_list_obhook( Monitor* mon, const QDict* qdict ) {
             monitor_printf( mon, "    %016lx: \n", ht_proc_rec->addr );
             LL_FOREACH( ht_proc_rec->cb_list, cb_rec ) {
                 monitor_printf( mon, "\t%5d, %10s, %16s\n", 
-                            cb_rec->uid,
+                            cb_rec->uniq_d,
                             (cb_rec->enabled)? "enabled" : "disabled",
                             cb_rec->label );
             }

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -86,13 +86,13 @@ typedef struct obhk_cb_record obhk_cb_record;
 
 struct obhook_context {
 
-    // 2-layers lookup hash table for out-of-box hook
-    //   The 1-layer is indexed by process CR3
-    //   The 2-layer is indexed by address where the hook implanted at
-    //
-    // Note that the hash record with CR3=0 indicates 
-    // the universal hooks, which are trigger regardless 
-    // of processes and the address is in kernel space.
+    /// 2-layers lookup hash table for out-of-box hook
+    ///   The 1-layer is indexed by process CR3
+    ///   The 2-layer is indexed by address where the hook implanted at
+    ///
+    /// Note that the hash record with CR3=0 indicates 
+    /// the universal hooks, which are trigger regardless 
+    /// of processes and the address is in kernel space.
     obhk_ht_record* hook_tbl;
 
     // the fast lookup table indexed by obhook descriptors
@@ -101,8 +101,8 @@ struct obhook_context {
     // record the top obhook descriptor number (for performance optimization)
     int top_d;
 
-    // a thread context to make the hash table thread-safe
-    pthread_mutex_t mtx;
+    // read-write lock to protect the internal data of OBHook (UTHASH not fully thread-safe)
+    pthread_rwlock_t rwlock;
 };
 typedef struct obhook_context obhook_context;
 

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -69,8 +69,8 @@ struct obhk_cb_record {
     // a reverse-pointer to the hash table record
     struct obhk_ht_record* ht_rec;
 
-    // unique identifier for each hook
-    uint16_t uid;
+    // unique descriptor as the identifier of an obhook
+    uint16_t uniq_d;
 
     bool enabled;
     bool universal;
@@ -95,8 +95,14 @@ struct obhook_context {
     // of processes and the address is in kernel space.
     obhk_ht_record* hook_tbl;
 
-    // the fast index table for queries to registered hook
+    // the fast lookup table indexed by obhook descriptors
     obhk_cb_record* index_tbl[MAX_NM_OBHOOK];
+
+    // record the top obhook descriptor number (for performance optimization)
+    int top_d;
+
+    // a thread context to make the hash table thread-safe
+    pthread_mutex_t mtx;
 };
 typedef struct obhook_context obhook_context;
 

--- a/ext/obhook/test/obhook_unittest.cc
+++ b/ext/obhook/test/obhook_unittest.cc
@@ -32,28 +32,28 @@ struct hook_func {
     virtual void* calloc( size_t, size_t ) = 0;
 
     // obhook functions/API
-    virtual int  get_obhook_uid( void ) = 0;
+    virtual int  get_obhook_descriptor( void ) = 0;
 };
 
 struct mock_func : hook_func {
     public:
         MOCK_METHOD2( calloc, void*(size_t, size_t) );
-        MOCK_METHOD0( get_obhook_uid, int() );
+        MOCK_METHOD0( get_obhook_descriptor, int() );
 
 } *mock_ptr;
 
 #define GEN_MOCK_OBJECT(x)  mock_func x; mock_ptr = &x;
 
 // mock the functions in the original code
-#define calloc(x, y)      mock_ptr->calloc(x, y)
-#define get_obhook_uid(x) mock_ptr->get_obhook_uid(x)
+#define calloc(x, y)             mock_ptr->calloc(x, y)
+#define get_obhook_descriptor(x) mock_ptr->get_obhook_descriptor(x)
 
 extern "C" {
 #include "../obhook.c"
 }
 
 #undef calloc
-#undef get_obhook_uid
+#undef get_obhook_descriptor
 
 // dummy callback for the obhook registration test
 void* dummy_cb( void* arg ) {
@@ -63,7 +63,7 @@ void* dummy_cb( void* arg ) {
 using namespace ::testing;
 
 TEST( GetUidTest, NormalCondition ) {
-    ASSERT_NE( -1, _get_obhook_uid() );
+    ASSERT_NE( -1, _get_obhook_descriptor() );
 }
 TEST( GetUidTest, FullCondition ) {
 
@@ -73,7 +73,7 @@ TEST( GetUidTest, FullCondition ) {
     for( int i = 0; i < MAX_NM_OBHOOK; ++i ) 
         obhk_ctx->index_tbl[i] = (obhk_cb_record*)dummy;
     // hook space should be (simulated) full now
-    ASSERT_EQ( -1, _get_obhook_uid() );
+    ASSERT_EQ( -1, _get_obhook_descriptor() );
 
     // restore shared resource
     for( int i = 0; i < MAX_NM_OBHOOK; ++i ) 
@@ -92,43 +92,43 @@ TEST( KernelAddrCheckTest, InvalidKernelAddress ) {
 
 TEST( AddUnivHookTest, FullHookErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Return(-1) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Return(-1) );
     ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_FULL_HOOK, obhook_errno );
 }
 TEST( AddUnivHookTest, InvalidAddressErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     ASSERT_EQ( -1, obhook_add_universal(0x0000000000000000, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_ADDR, obhook_errno );
 }
 TEST( AddUnivHookTest, LongLabelErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_LABEL, obhook_errno );
 }
 TEST( AddUnivHookTest, InvalidCallbackErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_CALLBACK, obhook_errno );
 }
 TEST( AddUnivHookTest, MemoryErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillOnce( ReturnNull() );
     ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).Times(2).WillOnce( Invoke(calloc) ).WillOnce( ReturnNull() );
     ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 }
 TEST( AddUnivHookTest, NormalCondition ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     ASSERT_EQ( 0, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
 }
@@ -140,43 +140,43 @@ TEST( AddProcHookTest, InvalidCR3ErrorHandle ) {
 }
 TEST( AddProcHookTest, FullHookErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Return(-1) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Return(-1) );
     ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_FULL_HOOK, obhook_errno );
 }
 TEST( AddProcHookTest, LongLabelErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_LABEL, obhook_errno );
 }
 TEST( AddProcHookTest, InvalidCallbackErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_CALLBACK, obhook_errno );
 }
 TEST( AddProcHookTest, MemoryErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillOnce( ReturnNull() );
     ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).Times(2).WillOnce( Invoke(calloc) ).WillOnce( ReturnNull() );
     ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 }
 TEST( AddProcHookTest, NormalConditionWithUserAddr ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0x0000ffffffffffff, "label", dummy_cb) );
 }
 TEST( AddProcHookTest, NormalConditionWithKernAddr ) {
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
 }
@@ -192,7 +192,7 @@ TEST( GetUnivHookTest, HookFound ) {
     obhk_cb_record* rec;
 
     // register a new universal hook
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     hook_d = obhook_add_universal( addr, label, dummy_cb );
     ASSERT_NE( -1, hook_d );
@@ -200,7 +200,7 @@ TEST( GetUnivHookTest, HookFound ) {
     // get the hook & check record
     rec = obhook_getcbs_univ( addr );
     ASSERT_TRUE( rec != NULL );
-    ASSERT_EQ( hook_d,  rec->uid );
+    ASSERT_EQ( hook_d,  rec->uniq_d );
     ASSERT_TRUE( rec->universal );
     ASSERT_TRUE( rec->enabled );
     ASSERT_STREQ( label, rec->label );
@@ -222,7 +222,7 @@ TEST( GetProcHookTest, HookFound ) {
     obhk_cb_record* rec;
 
     // register a new process hook
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     hook_d = obhook_add_process( cr3, addr, label, dummy_cb );
     ASSERT_NE( -1, hook_d );
@@ -230,7 +230,7 @@ TEST( GetProcHookTest, HookFound ) {
     // get the hook & check record
     rec = obhook_getcbs_proc( cr3, addr );
     ASSERT_TRUE( rec != NULL );
-    ASSERT_EQ( hook_d,  rec->uid );
+    ASSERT_EQ( hook_d,  rec->uniq_d );
     ASSERT_FALSE( rec->universal );
     ASSERT_TRUE( rec->enabled );
     ASSERT_STREQ( label, rec->label );
@@ -245,7 +245,7 @@ TEST( GetProcHookTest, HookNotFound ) {
     const char*  label = "proc_label";
 
     // register a new process hook
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     ASSERT_NE( -1, obhook_add_process(cr3, addr, label, dummy_cb) );
 
@@ -268,7 +268,7 @@ TEST( ToggleHookTest, HookDisableAndEnable ) {
     obhk_cb_record* rec;
 
     // register a new universal hook
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     hook_d = obhook_add_universal( addr, label, dummy_cb );
     ASSERT_NE( -1, hook_d );
@@ -323,7 +323,7 @@ TEST( DeleteHookTest, NormalCondition ) {
     target_ulong addr = 0xffffffffffffffff;
 
     GEN_MOCK_OBJECT( mock );
-    EXPECT_CALL( mock, get_obhook_uid() ).WillOnce( Invoke(_get_obhook_uid) );
+    EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     
     hook_d = obhook_add_process( cr3, addr, "to_be_deleted", dummy_cb );

--- a/target-i386/translate.c
+++ b/target-i386/translate.c
@@ -5178,6 +5178,20 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
     target_ulong next_eip, tval;
     int rex_w, rex_r;
 
+#if defined(CONFIG_OBHOOK)
+    uint32_t i;
+
+    hwaddr paddr_pc,
+           paddr_hk;
+
+    target_ulong page,
+                 current_cr3 = env->cr[3];
+
+    CPUState* cpu = ENV_GET_CPU(env);
+
+    obhk_ht_record* ht_rec;
+#endif
+
     if (unlikely(qemu_loglevel_mask(CPU_LOG_TB_OP | CPU_LOG_TB_OP_OPT))) {
         tcg_gen_debug_insn_start(pc_start);
     }
@@ -5194,8 +5208,7 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
     s->rip_offset = 0; /* for relative ip address */
     s->vex_l = 0;
     s->vex_v = 0;
- next_byte:
-    b = cpu_ldub_code(env, s->pc);
+
 #if defined(CONFIG_DIFT)
 #if defined(CONFIG_INDIRECT_TAINT)
     s->reg_base = R_NONE;
@@ -5215,11 +5228,38 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
 #if defined(CONFIG_OBHOOK)
     /// if any out-of-box hook is desired to be implanted
     /// generate the helper function as the runtime dispatcher
-    if( obhook_getcbs_univ(s->pc) != NULL 
-     || obhook_getcbs_proc(env->cr[3], s->pc) != NULL )
-        gen_helper_obhook_dispatcher( cpu_env );
+    ///
+    /// NOTE: we must use physical address to do the check.
+    ///       otherwise a proces-hook on shared code (library, syscall)
+    ///       will not be activated if the translation is conducted in
+    ///       aother process' context.
+
+    // iterate each obhook to compare its physical address with that of the current PC
+    page     = s->pc & TARGET_PAGE_MASK;
+    paddr_pc = cpu_get_phys_page_debug( cpu, page ) + (s->pc & ~TARGET_PAGE_MASK);
+    for( i = 0; i < MAX_NM_OBHOOK && i <= obhk_ctx->top_d; ++i ) {
+
+        if( obhk_ctx->index_tbl[i] == NULL )
+            continue;
+
+        ht_rec = obhk_ctx->index_tbl[i]->ht_rec;
+
+        env->cr[3] = ( ht_rec->cr3 == 0 )? current_cr3 : ht_rec->cr3;
+        page       = ht_rec->addr & TARGET_PAGE_MASK;
+        paddr_hk   = cpu_get_phys_page_debug( cpu, page ) + (ht_rec->addr & ~TARGET_PAGE_MASK);
+
+        if( paddr_pc == paddr_hk ) {
+            gen_helper_obhook_dispatcher( cpu_env );
+            break;
+        }
+    }
+
+    // restore the CPU context
+    env->cr[3] = current_cr3;
 #endif
 
+ next_byte:
+    b = cpu_ldub_code(env, s->pc);
     s->pc++;
     /* Collect prefixes.  */
     switch (b) {


### PR DESCRIPTION
1. fix the hooking-race issue among processes
2. enhance thread-safety
3. make the use of the 'descriptor' variable name consistent

minor revision of agent command spec.