### PR TITLE
DBA and NTM module motification

### DIFF
--- a/configure
+++ b/configure
@@ -1196,9 +1196,7 @@ for opt do
   ;;
   --disable-nettramon) nettramon="no"
   ;;
-  --disable-dba) 
-    echo "NOTE: DBA relies on almost every MBA extension!!"
-    dba="no"
+  --disable-dba) dba="no"
   ;;
   #########################
   *)

--- a/configure
+++ b/configure
@@ -1180,6 +1180,26 @@ for opt do
     nettramon="yes"
     dba="yes"
   ;;
+  --disable-dift) dift="no"
+  ;;
+  --disable-debug-dift) dift_debug="no"
+  ;;
+  --disable-agent) agent="no"
+  ;;
+  --disable-memfrs) memfrs="no"
+  ;;
+  --disable-tsk) tsk="no"
+  ;;
+  --disable-obhook) obhook="no"
+  ;;
+  --disable-tracer) tracer="no"
+  ;;
+  --disable-nettramon) nettramon="no"
+  ;;
+  --disable-dba) 
+    echo "NOTE: DBA relies on almost every MBA extension!!"
+    dba="no"
+  ;;
   #########################
   *)
       echo "ERROR: unknown option $opt"

--- a/ext/agent/agent-commands.c
+++ b/ext/agent/agent-commands.c
@@ -89,6 +89,7 @@ void do_win_expo( Monitor *mon, const QDict *qdict )  {
 }
 
 void do_win_exec( Monitor *mon, const QDict *qdict ) {
+   
     MBA_AGENT_RETURN ret;
 
     char* cmdline = (char*)qdict_get_str(qdict, "cmdline");
@@ -119,6 +120,7 @@ void do_win_exec( Monitor *mon, const QDict *qdict ) {
 }
 
 void do_win_invo( Monitor *mon, const QDict *qdict ) {
+    
     MBA_AGENT_RETURN ret;
 
     char* cmdline = (char*)qdict_get_str(qdict, "cmdline");
@@ -150,6 +152,7 @@ void do_win_invo( Monitor *mon, const QDict *qdict ) {
 }
 
 void do_win_logf( Monitor *mon, const QDict *qdict ) {
+    
     MBA_AGENT_RETURN ret;
 
     char* dst_path = (char*)qdict_get_str(qdict, "dstpath");
@@ -180,6 +183,7 @@ void do_win_logf( Monitor *mon, const QDict *qdict ) {
 }
 
 void do_win_init( Monitor *mon, const QDict *qdict ) {
+
     MBA_AGENT_RETURN ret;
 
     // initialize agent

--- a/ext/dba/dba-commands-spec.h
+++ b/ext/dba/dba-commands-spec.h
@@ -39,8 +39,9 @@
 },
 {
         .name         = "mba_show_dba_result",
-        .args_type    = "tid:i",
-        .params       = "task_id",
-        .help         = "Show the analysis result of the DBA task specified by ID",
+        .args_type    = "tid:i,file:F",
+        .params       = "task_id [file]",
+        .help         = "Show the analysis result of the DBA task specified by ID." \
+                        "Can specify a file in order to write into it.",
         .mhandler.cmd = do_show_dba_result,
 },

--- a/ext/dba/dba-commands-spec.h
+++ b/ext/dba/dba-commands-spec.h
@@ -18,8 +18,8 @@
  */
 {
         .name         = "mba_start_dba",
-        .args_type    = "sample:F,timer:i",
-        .params       = "sample timer",
+        .args_type    = "sample:F,timer:i,config:F?",
+        .params       = "sample timer [config]",
         .help         = "Start dynamic behavior analysis(DBA) on the given sample",
         .mhandler.cmd = do_start_dba_task,
 },

--- a/ext/dba/dba-commands.c
+++ b/ext/dba/dba-commands.c
@@ -2,16 +2,32 @@
 
 #include "ext/dba/dba.h"
 #include "ext/dba/dba-commands.h"
+#include "ext/agent/agent-commands.h"
 
 #define PROMPT_DBA_Q1 "DBA - Enable taint analysis? [y/n]: "
 #define PROMPT_DBA_Q2 "DBA - Taint tag [1~127]: "
 #define PROMPT_DBA_Q3 "DBA - Enable syscall tracer? [y/n]: "
 #define PROMPT_DBA_Q4 "DBA - Start analysis? [y/n]: "
 
+#define CONFIG_TAG_MODULE          "MODULE"
+#define CONFIG_TAG_AGENT           "AGENT"
+#define CONFIG_TAG_DIFT            "DIFT"
+#define CONFIG_TAG_OBHOOK          "OBHOOK"
+#define CONFIG_TAG_NETTRAMON       "NETTRAMON"
+#define CONFIG_TAG_TAINT           "TAINT"
+#define CONFIG_TAG_ENABLE          "ENABLE"
+#define CONFIG_TAG_YES             "yes"
+#define CONFIG_TAG_Y               "y"
+#define CONFIG_TAG_NO              "no"
+#define CONFIG_TAG_TAINT_TAG       "TAG"
+#define CONFIG_TAG_SYSCALL_TRACER  "SYSCALL_TRACER"
+
 static void cb_dba_confirm( void* mon, const char* yn, void* opaque );
 static void cb_dba_set_syscall( void* mon, const char* yn, void* opaque );
 static void cb_dba_set_taint_tag( void* mon, const char* yn, void* opaque );
 static void cb_dba_set_taint( void* mon, const char* yn, void* opaque );
+
+bool use_config_file = FALSE;
 
 static void show_dba_context_info( Monitor* mon, const dba_context* ctx ) {
 
@@ -34,11 +50,16 @@ static inline void show_dba_report_title( Monitor* mon, const char* str ) {
 // DBA - confirm ?
 static void cb_dba_confirm( void* mon, const char* yn, void* opaque ) {
 
+    monitor_printf( mon, "========== Task Info ==========\n" );
+    show_dba_context_info( mon, dba_get_task_context((DBA_TID)opaque) );
+   
     // confirmed, start analysis
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
 
         // initiate DBA analysis
         if( dba_start_analysis((DBA_TID)opaque) != 0 ) {
+
+            monitor_printf( mon, "\n****** ERROR ******\n" );
             
             switch( dba_errno ) {
                 case DBA_ERR_INVALID_TID:
@@ -68,6 +89,13 @@ static void cb_dba_confirm( void* mon, const char* yn, void* opaque ) {
             }
             dba_delete_task( (DBA_TID)opaque );
         }
+        else {
+            monitor_printf( mon, "=== Please wait for finish message ===\n" );
+        }
+        monitor_read_command( mon, 1 );
+        return;
+    }
+    else {
         monitor_read_command( mon, 1 );
         return;
     }
@@ -90,7 +118,6 @@ static void cb_dba_set_syscall( void* mon, const char* yn, void* opaque ) {
     // goto confirm
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         dba_enable_syscall_trace( (DBA_TID)opaque );
-        show_dba_context_info( mon, dba_get_task_context((DBA_TID)opaque) );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q4, 0, cb_dba_confirm, opaque );
         mba_readline_show_prompt( mon );
         return;
@@ -99,7 +126,6 @@ static void cb_dba_set_syscall( void* mon, const char* yn, void* opaque ) {
     // goto confirm
     if( strcasecmp( "n", yn ) == 0 || strcasecmp( "no", yn ) == 0 ) {
         dba_disable_syscall_trace( (DBA_TID)opaque );
-        show_dba_context_info( mon, dba_get_task_context((DBA_TID)opaque) );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q4, 0, cb_dba_confirm, opaque );
         mba_readline_show_prompt( mon );
         return;
@@ -159,13 +185,127 @@ static void cb_dba_set_taint( void* mon, const char* yn, void* opaque ) {
     mba_readline_show_prompt( mon );
 }
 
+// Set dba enviroment via config file
+// Return 0 for success, 1 for fail
+static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void* opaque ) {
+   
+    json_object*    jo_config;
+    json_object*    jo_taint;
+    json_object*    jo_syscall;
+    json_object*    jo_module;
+
+    if ( ( jo_config = json_object_from_file( config_file_path ) ) == NULL ) {
+        monitor_printf( mon, "Read config file fail\n");
+        return 1;
+    }
+
+    monitor_printf( mon, "====== Start to Enable Modules ======\n\n" );
+
+    // Enable modules
+    if ( json_object_object_get_ex( (json_object*)jo_config, CONFIG_TAG_MODULE, &jo_module ) ) {
+
+        json_object*    jo_now_module;
+
+        // Enable Agent
+        if ( json_object_object_get_ex( jo_module, CONFIG_TAG_AGENT, &jo_now_module ) ) {
+            if ( strcmp( json_object_get_string( jo_now_module ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_now_module ), CONFIG_TAG_Y ) == 0 ) {
+                do_win_init( mon, NULL );
+                monitor_printf( mon, "Enable Agent Successfully\n\n");
+            }
+            else {
+                monitor_printf( mon, "Do nothing to Agent\n\n");
+            }
+        }
+        // Enable DIFT
+        if ( json_object_object_get_ex( jo_module, CONFIG_TAG_DIFT, &jo_now_module ) ) {
+            if ( strcmp( json_object_get_string( jo_now_module ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_now_module ), CONFIG_TAG_Y ) == 0 ) {
+                //dift_enable();
+            }
+            else {
+                monitor_printf( mon, "Do nothing to Dift\n\n");
+            }
+        }
+        // Enable Nettramon
+        if ( json_object_object_get_ex( jo_module, CONFIG_TAG_NETTRAMON, &jo_now_module ) ) {
+            if ( strcmp( json_object_get_string( jo_now_module ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_now_module ), CONFIG_TAG_Y ) == 0 ) {
+                nettramon_start( NULL );
+                monitor_printf( mon, "Enable Nettramon Successfully\n\n");
+            }
+            else {
+                monitor_printf( mon, "Do nothing to Nettramon\n\n");
+            }
+        }
+
+    }
+    monitor_printf( mon, "====== Finish Enabling Modules ======\n" );
+
+    // Set Taint
+    if ( json_object_object_get_ex( (json_object*)jo_config, CONFIG_TAG_TAINT, &jo_taint ) ) {
+        
+        json_object* jo_taint_enable;
+        json_object* jo_taint_tag;
+        if ( json_object_object_get_ex( jo_taint, CONFIG_TAG_ENABLE, &jo_taint_enable ) ) {
+            if ( ( strcmp( json_object_get_string( jo_taint_enable ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_taint_enable ), CONFIG_TAG_Y ) == 0 ) && json_object_object_get_ex( jo_taint, CONFIG_TAG_TAINT_TAG, &jo_taint_tag ) ) {
+                cb_dba_set_taint_tag( mon, json_object_get_string( jo_taint_tag ), opaque );
+            }
+            else {
+                if ( strcmp( json_object_get_string( jo_taint_enable ), CONFIG_TAG_NO ) != 0 ) {
+                    monitor_printf( mon, "Taint set fail\n");
+                    return 1;
+                }
+                else {
+                    cb_dba_set_taint( mon, "n", opaque ); 
+                }
+            }
+        }
+        else {
+            monitor_printf( mon, "Cannot get taint enable json\n");
+            return 1;
+        }
+    }
+    else {
+        monitor_printf( mon, "Cannot get taint json\n");
+        return 1;
+    }
+
+    // Set Syscall tracer
+    if ( json_object_object_get_ex( (json_object*)jo_config, CONFIG_TAG_SYSCALL_TRACER, &jo_syscall ) ) {
+        json_object* jo_syscall_enable;
+        if ( json_object_object_get_ex( jo_syscall, CONFIG_TAG_ENABLE, &jo_syscall_enable ) ) {
+            if ( ( strcmp( json_object_get_string( jo_syscall_enable ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_syscall_enable ), CONFIG_TAG_Y ) == 0 ) ) {
+                cb_dba_set_syscall( NULL, json_object_get_string( jo_syscall_enable ), opaque );
+            }
+            else {
+                if ( strcmp( json_object_get_string( jo_syscall_enable ), CONFIG_TAG_NO ) != 0 ) {
+                    monitor_printf( mon, "Syscall set fail\n");
+                    return 1;
+                }
+                else {
+                    cb_dba_set_syscall( NULL, "n", opaque );
+                }
+            }
+        }
+        else {
+            monitor_printf( mon, "Cannot get syscall enable json\n");
+            return 1;
+        }
+    }
+    else {
+        monitor_printf( mon, "Cannot get syscall json\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 void do_start_dba_task( Monitor* mon, const QDict* qdict ) {
 
     DBA_TID tid;
 
     const char* sample = qdict_get_str( qdict, "sample" );
     uint32_t timer     = qdict_get_int( qdict, "timer" );
-
+    const char* config_file_path = qdict_get_try_str( qdict, "config" );
+    
     // allocate new DBA context
     tid = dba_new_task();
     if( tid == -1 ) {
@@ -225,12 +365,38 @@ void do_start_dba_task( Monitor* mon, const QDict* qdict ) {
         return;
     }
 
-    // callback chain as questions to setup DBA context
-    //  1. ask user for taint option
-    //  2. if taint is enabled, ask taint tag
-    //  3. ask user for syscall trace option
-    //  4. final confirm & launch analysis
-    mba_readline_start( (void*)mon, PROMPT_DBA_Q1, 0, cb_dba_set_taint, (void*)tid );
+    // Set monitor pointer to the task in order to print out the finish message
+    if ( dba_set_monitor( tid, mon ) != 0 ) {
+        monitor_printf( mon, "Set monitor pointer fail\n");
+        return;
+    }
+
+    if ( config_file_path != NULL ) {
+
+        use_config_file = TRUE;
+        monitor_printf( mon, "Set with config file\n" );
+        if ( dba_set_by_config( mon, config_file_path, (void*)tid ) != 0 ) {
+            monitor_printf( mon, "Set task by config file fail\n");
+            use_config_file = FALSE;
+        }
+        else {
+            use_config_file = FALSE;
+            cb_dba_confirm( mon, "yes", (void*)tid );
+        }
+    }
+    else {
+
+        use_config_file = FALSE;
+        monitor_printf( mon, "Set without config file\n" );
+
+        // callback chain as questions to setup DBA context
+        //  1. ask user for taint option
+        //  2. if taint is enabled, ask taint tag
+        //  3. ask user for syscall trace option
+        //  4. final confirm & launch analysis
+        mba_readline_start( (void*)mon, PROMPT_DBA_Q1, 0, cb_dba_set_taint, (void*)tid );
+    }
+
 }
 
 void do_list_dba_task( Monitor* mon, const QDict* qdict ) {
@@ -338,4 +504,10 @@ void do_show_dba_result( Monitor* mon, const QDict* qdict ) {
             }
         }
     }
+}
+
+bool do_dba_config_file_setting ( void ) {
+
+    return use_config_file ;
+
 }

--- a/ext/dba/dba-commands.c
+++ b/ext/dba/dba-commands.c
@@ -371,6 +371,7 @@ void do_start_dba_task( Monitor* mon, const QDict* qdict ) {
         return;
     }
 
+    // Set by the config file
     if ( config_file_path != NULL ) {
 
         use_config_file = TRUE;
@@ -506,6 +507,8 @@ void do_show_dba_result( Monitor* mon, const QDict* qdict ) {
     }
 }
 
+// Used to check which setting mode is now
+// Return TRUE for setting by config file, FALSE for command line setting
 bool do_dba_config_file_setting ( void ) {
 
     return use_config_file ;

--- a/ext/dba/dba-commands.h
+++ b/ext/dba/dba-commands.h
@@ -27,4 +27,5 @@ void do_start_dba_task( Monitor* mon, const QDict* qdict );
 void do_list_dba_task( Monitor* mon, const QDict* qdict );
 void do_delete_dba_task( Monitor* mon, const QDict* qdict );
 void do_show_dba_result( Monitor* mon, const QDict* qdict );
+bool do_dba_config_file_setting ( void );
 #endif

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -143,7 +143,10 @@ static DBA_TID get_available_tid( void ) {
 #define AGENT_ACT( x ) \
     while( (aret = x) == AGENT_RET_EBUSY ) { asm volatile("pause"); } \
     while( !agent_is_idle() ) { asm volatile( "pause" ); }
-static void invoke_sample( dba_context* ctx ) {
+
+// Wrpper of invoking sample and doing sync
+// Return none
+static void* invoke_sample( dba_context* ctx ) {
 
     MBA_AGENT_RETURN aret;
 
@@ -155,8 +158,12 @@ static void invoke_sample( dba_context* ctx ) {
 
     // flush buffered read/write of the guest OS
     AGENT_ACT( agent_sync() );
+
+    return NULL;
 }
 
+// dba task thread main
+// retirn none
 static void* dba_main_internal( void* ctx_arg ) {
 
     MBA_AGENT_RETURN aret;
@@ -270,16 +277,7 @@ int dba_set_monitor( DBA_TID tid, Monitor* mon ) {
     dba_tasks[tid]->mon = mon;
     return 0;
 }
-/*
-int dba_set_ntm_cb ( DBA_TID tid ) {
 
-    if( !is_task_configurable(tid) ) 
-        return -1;
-
-    dba_tasks[tid]->ntm_cb_id = nettramon_set_cb( &tainted_packet_cb, &dba_tasks[tid] );
-    return 0;
-}
-*/
 int dba_set_timer( DBA_TID tid, size_t seconds ) {
 
     if( !is_task_configurable(tid) ) 

--- a/ext/dba/dba.h
+++ b/ext/dba/dba.h
@@ -115,15 +115,7 @@ extern int dba_delete_task( DBA_TID tid );
 /// Return a pointer to a constant DBA context object on success,
 /// otherwise NULL is returned
 extern const dba_context* dba_get_task_context( DBA_TID tid );
-/*
-/// Set the call back funciton to the nettramon
-/// Note that the task must be IDLE to be configurable
-///
-///     \param  tid         DBA task ID
-///
-/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
-extern int dba_set_ntm_cb( DBA_TID tid );
-*/
+
 /// Set the monitor pointer to let task inform user of finishing sample execution
 /// Note that the task must be IDLE to be configurable
 ///

--- a/ext/dba/dba.h
+++ b/ext/dba/dba.h
@@ -26,13 +26,16 @@
 #include "ext/tsk/tsk.h"
 #include "ext/dift/dift.h"
 #include "ext/agent/agent.h"
+#include "ext/nettramon/nettramon.h"
+#include "monitor/monitor.h"
 
-#define DBA_MAX_TASKS        0x1000
-#define DBA_MAX_FILENAME     255
-#define DBA_GUEST_SAMPLE_DIR "/Users/dsns/Desktop/" 
+#define DBA_MAX_TASKS               0x1000
+#define DBA_MAX_FILENAME            255
+#define DBA_GUEST_SAMPLE_DIR        "/Users/dsns/Desktop/"
+#define DBA_MAX_TAINT_PACKET_LENGTH 1024 
 
-#define DBA_JSON_KEY_TAINT   "TAINT"
-#define DBA_JSON_KEY_SYSCALL "SYSCALL"
+#define DBA_JSON_KEY_TAINT          "TAINT"
+#define DBA_JSON_KEY_SYSCALL        "SYSCALL"
 
 // DBA Task ID
 typedef intptr_t DBA_TID;
@@ -79,6 +82,8 @@ struct dba_context {
     pthread_t thread;
 
     DBA_TASK_STATE state;
+
+    Monitor* mon;
 };
 typedef struct dba_context dba_context;
 
@@ -110,7 +115,23 @@ extern int dba_delete_task( DBA_TID tid );
 /// Return a pointer to a constant DBA context object on success,
 /// otherwise NULL is returned
 extern const dba_context* dba_get_task_context( DBA_TID tid );
-
+/*
+/// Set the call back funciton to the nettramon
+/// Note that the task must be IDLE to be configurable
+///
+///     \param  tid         DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_set_ntm_cb( DBA_TID tid );
+*/
+/// Set the monitor pointer to let task inform user of finishing sample execution
+/// Note that the task must be IDLE to be configurable
+///
+///     \param  tid         DBA task ID
+///     \param  mon         pointer to the QENU monitor
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_set_monitor( DBA_TID tid, Monitor* mon );
 
 /// Set the timer for the sample execution for the DBA task by ID
 /// Note that the task must be IDLE to be configurable

--- a/ext/dba/dba_taint.c
+++ b/ext/dba/dba_taint.c
@@ -3,11 +3,13 @@
 #include "qemu/thread.h"
 #include "qmp-commands.h"
 #include "include/utarray.h"
+#include "include/exec/cpu-common.h"
 
 // define Report Field Title for each taint analysis items
 #define RFT_TAINTED_FILE       "Tainted File"
 #define RFT_TAINTED_REGISTRY   "Tainted Registry"
 #define RFT_BOOTCODE           "Tainted Bootcode"
+#define RFT_TAINTED_PACKET     "Tainted Packet"
 
 extern QemuMutex qemu_global_mutex;
 
@@ -36,6 +38,113 @@ static const char* get_device_image( const char* dev ) {
                 return info->value->inserted->file;
     }
     return NULL;
+}
+
+// Print out the content in buf into json_packet_content if the length of json_packet_content is not full
+// Return 0 if success, 1 for full json_packet_content or fail
+static int json_packet_content_sprintf( char* json_packet_content, const char* fmt, ... ) {
+
+    char    tmp[DBA_MAX_TAINT_PACKET_LENGTH];
+    va_list args;
+    
+    va_start( args, fmt );
+    vsprintf( tmp, fmt, args );
+    va_end( args );
+
+    if ( strlen( json_packet_content ) + strlen( tmp ) >= DBA_MAX_TAINT_PACKET_LENGTH )
+        return 1;
+
+    strncat( json_packet_content, tmp, strlen(tmp) );
+
+    return 0;
+
+}
+
+// Print out the payload in hex and ascii format in one line
+// Return none
+static void print_taint_packet_line( char* json_packet_content, const u_char *payload, int len, int offset) {
+    
+    int i;
+    const u_char *hex_head;
+    const u_char *ascii_head;
+
+    /* hex */
+    hex_head = payload;
+    for(i = 0; i < len; i++) {
+        if( json_packet_content_sprintf( json_packet_content, "%02x ", hex_head[i] ) ) 
+            return ;
+    }
+   
+    /* To align the content */
+    if ( len < 16 )
+        for ( i = len; i < 16; i++ )
+            if ( json_packet_content_sprintf( json_packet_content, "   ") )
+                return ;
+
+    if ( json_packet_content_sprintf( json_packet_content, "  ") )
+        return ;
+
+    /* print out ascii */
+    ascii_head = payload;
+    for(i = 0; i < len; i++) {
+        if ( isprint(ascii_head[i]) ) {
+            if ( json_packet_content_sprintf( json_packet_content, "%c", ascii_head[i]) )
+                return ;
+        }
+        else {
+            if ( json_packet_content_sprintf( json_packet_content, ".") )
+                return ;
+        }
+    }
+
+    json_packet_content_sprintf( json_packet_content, "\n");
+
+    return;
+}
+
+// Print out the payload to the json_packet_content
+// Return none
+static void print_taint_packet_payload( char* json_packet_content, const u_char *payload, int len ) {
+    
+    int len_remain = len;
+    int line_width = 16;            /* number of bytes per line */
+    int line_len;
+    int offset = 0;                 /* zero-based offset counter */
+    const u_char *pl_head = payload;
+
+    if (len <= 0)
+        return;
+
+    if ( json_packet_content_sprintf( json_packet_content, "Tainted Packet Payload: \n" ) )
+        return;
+
+    /* data fits on one line */
+    if (len <= line_width) {
+        print_taint_packet_line(json_packet_content, pl_head, len, offset);
+        return;
+    }
+
+    /* data spans multiple lines */
+    for ( ;; ) {
+        /* compute current line length */
+        line_len = line_width % len_remain;
+        /* print line */
+        print_taint_packet_line(json_packet_content, pl_head, line_len, offset);
+        /* compute total remaining */
+        len_remain = len_remain - line_len;
+        /* shift pointer to remaining bytes to print */
+        pl_head = pl_head + line_len;
+        /* add offset */
+        offset = offset + line_width;
+        /* check if we have line width chars or less */
+        if (len_remain <= line_width) {
+            /* print last line and get out */
+            print_taint_packet_line(json_packet_content, pl_head, len_remain, offset);
+            break;
+        }
+    }
+
+    return;
 }
 
 int set_sample_tainted( dba_context* ctx ) {
@@ -159,3 +268,179 @@ int enum_tainted_registry( dba_context* ctx ) {
     // TODO: tainted registry parsing
     return 1;
 }
+/*
+static void print_tainted_byte( uint64_t len, uint64_t begin, packet_info* packet_ptr ) {
+
+    uint64_t tmp_b = begin;
+    uint64_t tmp_dis, i;
+
+    printf("\nTaint byte:\n");
+    printf("ethernet header: ");
+    tmp_dis = (u_char*)packet_ptr->ip_head - (u_char*)packet_ptr->eth_head;
+    for ( i = 0; i < tmp_dis; i++ ) {
+        if( dift_get_memory_dirty(tmp_b) ) {
+            printf("%" PRIu64 " ", tmp_b - begin );
+         }
+         tmp_b++;
+    }
+    printf("\n");
+    switch( packet_ptr->packet_protocol ) {
+        case NETTRAMON_PRO_TCP:
+            printf("ip header: ");
+            tmp_dis = (u_char*)packet_ptr->tcp_head - (u_char*)packet_ptr->ip_head;
+            for ( i = 0; i < tmp_dis; i++ ) {
+                if( dift_get_memory_dirty(tmp_b) ) {
+                    printf("%" PRIu64 " ", tmp_b - begin );
+                 }
+                 tmp_b++;
+            }
+            printf("\n");
+            printf("tcp header: ");
+            tmp_dis = (u_char*)packet_ptr->payload - (u_char*)packet_ptr->tcp_head;
+            for ( i = 0; i < tmp_dis; i++ ) {
+                if( dift_get_memory_dirty(tmp_b) ) {
+                    printf("%" PRIu64 " ", tmp_b - begin );
+                 }
+                 tmp_b++;
+            }
+            printf("\n");
+            break;
+        case NETTRAMON_PRO_UDP:
+            printf("ip header: ");
+            tmp_dis = (u_char*)packet_ptr->udp_head - (u_char*)packet_ptr->ip_head;
+            for ( i = 0; i < tmp_dis; i++ ) {
+                if( dift_get_memory_dirty(tmp_b) ) {
+                    printf("%" PRIu64 " ", tmp_b - begin );
+                 }
+                 tmp_b++;
+            }
+            printf("\n");
+            printf("udp header: ");
+            tmp_dis = (u_char*)packet_ptr->payload - (u_char*)packet_ptr->udp_head;
+            for ( i = 0; i < tmp_dis; i++ ) {
+                if( dift_get_memory_dirty(tmp_b) ) {
+                    printf("%" PRIu64 " ", tmp_b - begin );
+                 }
+                 tmp_b++;
+            }
+            printf("\n");
+            break;
+        case NETTRAMON_PRO_ICMP:
+            printf("ip header: ");
+            tmp_dis = (u_char*)packet_ptr->icmp_head - (u_char*)packet_ptr->ip_head;
+            for ( i = 0; i < tmp_dis; i++ ) {
+                if( dift_get_memory_dirty(tmp_b) ) {
+                    printf("%" PRIu64 " ", tmp_b - begin );
+                 }
+                 tmp_b++;
+            }
+            printf("\n");
+            printf("icmp header: ");
+            tmp_dis = (u_char*)packet_ptr->payload - (u_char*)packet_ptr->icmp_head;
+            for ( i = 0; i < tmp_dis; i++ ) {
+                if( dift_get_memory_dirty(tmp_b) ) {
+                    printf("%" PRIu64 " ", tmp_b - begin );
+                 }
+                 tmp_b++;
+            }
+            printf("\n");
+            break;
+        case NETTRAMON_PRO_UNKNOWN:
+        default:
+            break;
+    }
+
+    uint64_t j = packet_ptr->payload - (u_char*)packet_ptr->eth_head;
+    printf("payload: ");
+    if ( j < len ) {
+        for( i = 0; i < len-j; i++ ) {
+            if( dift_get_memory_dirty(tmp_b) ) {
+                printf("%" PRIu64 " ", tmp_b - begin );
+            }
+            tmp_b++;
+        }
+        printf("\n");
+    }
+    printf("\n");
+}
+*/
+void* tainted_packet_cb( size_t len, uint64_t packet_haddr, void* ctx ) {
+    
+    uint64_t        begin, end;
+    u_char*         buf;
+    char            json_packet_content[DBA_MAX_TAINT_PACKET_LENGTH] = {0};
+    char            tmp[DBA_MAX_TAINT_PACKET_LENGTH] = {0};
+    int             print_len;
+    packet_info*    packet_ptr;
+
+    json_object*    jo_taint_report;
+    json_object*    jo_taint_packet;
+    
+    // get JSON object for taint result
+    json_object_object_get_ex( ((dba_context*)ctx)->result, DBA_JSON_KEY_TAINT, &jo_taint_report );
+    
+    // get JSON object for tainted result
+    // check if the JSON object is already in the tainted result
+    if ( !json_object_object_get_ex( jo_taint_report, RFT_TAINTED_PACKET, &jo_taint_packet ) ) {
+        // add array JSON object to store tainted packet
+        jo_taint_packet = json_object_new_array();
+        json_object_object_add( jo_taint_report, RFT_TAINTED_PACKET, jo_taint_packet );
+    }
+
+    begin = packet_haddr;
+    end = begin + len;
+
+    for(; begin < end; ++begin ) {
+        if( dift_get_memory_dirty(begin) && ((dba_context*)ctx)->state == DBA_TASK_BUSY ) {
+            buf = (u_char*)calloc( 1, len );
+            packet_ptr = (packet_info*)calloc( 1, sizeof(packet_info) );
+            cpu_physical_memory_read( packet_haddr, buf, len );
+            if ( nettramon_packet_parse( buf, len, packet_ptr ) == 0 ) {
+                switch( packet_ptr->packet_protocol ) {
+                    // Notice that the inet_ntoa puts string to a static buffer and returns the pointer of the static buffer,
+                    // which results in printing the same IP address if call it many times in the same sprintf.
+                    // Separate the calling operations into multiple sprintf and get the right IP address.
+                    case NETTRAMON_PRO_TCP:
+                        print_len = sprintf( tmp, "------TCP Packet------\nFrom: %s\t\t : ",inet_ntoa(packet_ptr->ip_head->ip_src)  );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%d\nTo:   ",                         packet_ptr->tcp_head->th_sport          );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%s\t : ",                              inet_ntoa(packet_ptr->ip_head->ip_dst)  );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%d\n",                               packet_ptr->tcp_head->th_dport          );
+                        strncat( json_packet_content, tmp, print_len );
+                        //print_tainted_byte( len, packet_haddr, packet_ptr );
+                        break; 
+                    case NETTRAMON_PRO_UDP:
+                        print_len = sprintf( tmp, "------UDP Packet------\nFrom: %s\t\t : ",inet_ntoa(packet_ptr->ip_head->ip_src)  );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%d\nTo:   ",                         packet_ptr->udp_head->uh_sport          );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%s\t : ",                              inet_ntoa(packet_ptr->ip_head->ip_dst)  );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%d\n",                               packet_ptr->udp_head->uh_dport          );
+                        strncat( json_packet_content, tmp, print_len );
+                        //print_tainted_byte( len, packet_haddr, packet_ptr );
+                        break;
+                    case NETTRAMON_PRO_ICMP:
+                        print_len = sprintf( tmp, "------ICMP Packet-----\nFrom: %s\t\t : ",inet_ntoa(packet_ptr->ip_head->ip_src)  );
+                        strncat( json_packet_content, tmp, print_len );
+                        print_len = sprintf( tmp, "%s\t : ",                              inet_ntoa(packet_ptr->ip_head->ip_dst)  );
+                        strncat( json_packet_content, tmp, print_len );
+                        //print_tainted_byte( len, packet_haddr, packet_ptr );
+                        break;
+                    case NETTRAMON_PRO_UNKNOWN:
+                    default:
+                        print_len = sprintf( tmp, "------UNKNOWN packet------" );
+                        strncat( json_packet_content, tmp, print_len );
+                        break;
+                }
+                print_taint_packet_payload( json_packet_content, packet_ptr->payload, packet_ptr->len );
+                json_object_array_add( jo_taint_packet, json_object_new_string( json_packet_content ) );
+            }
+            break;   
+        }
+    }
+    return NULL;
+}
+

--- a/ext/dba/dba_taint.c
+++ b/ext/dba/dba_taint.c
@@ -268,102 +268,7 @@ int enum_tainted_registry( dba_context* ctx ) {
     // TODO: tainted registry parsing
     return 1;
 }
-/*
-static void print_tainted_byte( uint64_t len, uint64_t begin, packet_info* packet_ptr ) {
 
-    uint64_t tmp_b = begin;
-    uint64_t tmp_dis, i;
-
-    printf("\nTaint byte:\n");
-    printf("ethernet header: ");
-    tmp_dis = (u_char*)packet_ptr->ip_head - (u_char*)packet_ptr->eth_head;
-    for ( i = 0; i < tmp_dis; i++ ) {
-        if( dift_get_memory_dirty(tmp_b) ) {
-            printf("%" PRIu64 " ", tmp_b - begin );
-         }
-         tmp_b++;
-    }
-    printf("\n");
-    switch( packet_ptr->packet_protocol ) {
-        case NETTRAMON_PRO_TCP:
-            printf("ip header: ");
-            tmp_dis = (u_char*)packet_ptr->tcp_head - (u_char*)packet_ptr->ip_head;
-            for ( i = 0; i < tmp_dis; i++ ) {
-                if( dift_get_memory_dirty(tmp_b) ) {
-                    printf("%" PRIu64 " ", tmp_b - begin );
-                 }
-                 tmp_b++;
-            }
-            printf("\n");
-            printf("tcp header: ");
-            tmp_dis = (u_char*)packet_ptr->payload - (u_char*)packet_ptr->tcp_head;
-            for ( i = 0; i < tmp_dis; i++ ) {
-                if( dift_get_memory_dirty(tmp_b) ) {
-                    printf("%" PRIu64 " ", tmp_b - begin );
-                 }
-                 tmp_b++;
-            }
-            printf("\n");
-            break;
-        case NETTRAMON_PRO_UDP:
-            printf("ip header: ");
-            tmp_dis = (u_char*)packet_ptr->udp_head - (u_char*)packet_ptr->ip_head;
-            for ( i = 0; i < tmp_dis; i++ ) {
-                if( dift_get_memory_dirty(tmp_b) ) {
-                    printf("%" PRIu64 " ", tmp_b - begin );
-                 }
-                 tmp_b++;
-            }
-            printf("\n");
-            printf("udp header: ");
-            tmp_dis = (u_char*)packet_ptr->payload - (u_char*)packet_ptr->udp_head;
-            for ( i = 0; i < tmp_dis; i++ ) {
-                if( dift_get_memory_dirty(tmp_b) ) {
-                    printf("%" PRIu64 " ", tmp_b - begin );
-                 }
-                 tmp_b++;
-            }
-            printf("\n");
-            break;
-        case NETTRAMON_PRO_ICMP:
-            printf("ip header: ");
-            tmp_dis = (u_char*)packet_ptr->icmp_head - (u_char*)packet_ptr->ip_head;
-            for ( i = 0; i < tmp_dis; i++ ) {
-                if( dift_get_memory_dirty(tmp_b) ) {
-                    printf("%" PRIu64 " ", tmp_b - begin );
-                 }
-                 tmp_b++;
-            }
-            printf("\n");
-            printf("icmp header: ");
-            tmp_dis = (u_char*)packet_ptr->payload - (u_char*)packet_ptr->icmp_head;
-            for ( i = 0; i < tmp_dis; i++ ) {
-                if( dift_get_memory_dirty(tmp_b) ) {
-                    printf("%" PRIu64 " ", tmp_b - begin );
-                 }
-                 tmp_b++;
-            }
-            printf("\n");
-            break;
-        case NETTRAMON_PRO_UNKNOWN:
-        default:
-            break;
-    }
-
-    uint64_t j = packet_ptr->payload - (u_char*)packet_ptr->eth_head;
-    printf("payload: ");
-    if ( j < len ) {
-        for( i = 0; i < len-j; i++ ) {
-            if( dift_get_memory_dirty(tmp_b) ) {
-                printf("%" PRIu64 " ", tmp_b - begin );
-            }
-            tmp_b++;
-        }
-        printf("\n");
-    }
-    printf("\n");
-}
-*/
 void* tainted_packet_cb( size_t len, uint64_t packet_haddr, void* ctx ) {
     
     uint64_t        begin, end;
@@ -403,31 +308,28 @@ void* tainted_packet_cb( size_t len, uint64_t packet_haddr, void* ctx ) {
                     case NETTRAMON_PRO_TCP:
                         print_len = sprintf( tmp, "------TCP Packet------\nFrom: %s\t\t : ",inet_ntoa(packet_ptr->ip_head->ip_src)  );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%d\nTo:   ",                         packet_ptr->tcp_head->th_sport          );
+                        print_len = sprintf( tmp, "%d\nTo:   ",                             packet_ptr->tcp_head->th_sport          );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%s\t : ",                              inet_ntoa(packet_ptr->ip_head->ip_dst)  );
+                        print_len = sprintf( tmp, "%s\t : ",                                inet_ntoa(packet_ptr->ip_head->ip_dst)  );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%d\n",                               packet_ptr->tcp_head->th_dport          );
+                        print_len = sprintf( tmp, "%d\n",                                   packet_ptr->tcp_head->th_dport          );
                         strncat( json_packet_content, tmp, print_len );
-                        //print_tainted_byte( len, packet_haddr, packet_ptr );
                         break; 
                     case NETTRAMON_PRO_UDP:
                         print_len = sprintf( tmp, "------UDP Packet------\nFrom: %s\t\t : ",inet_ntoa(packet_ptr->ip_head->ip_src)  );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%d\nTo:   ",                         packet_ptr->udp_head->uh_sport          );
+                        print_len = sprintf( tmp, "%d\nTo:   ",                             packet_ptr->udp_head->uh_sport          );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%s\t : ",                              inet_ntoa(packet_ptr->ip_head->ip_dst)  );
+                        print_len = sprintf( tmp, "%s\t : ",                                inet_ntoa(packet_ptr->ip_head->ip_dst)  );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%d\n",                               packet_ptr->udp_head->uh_dport          );
+                        print_len = sprintf( tmp, "%d\n",                                   packet_ptr->udp_head->uh_dport          );
                         strncat( json_packet_content, tmp, print_len );
-                        //print_tainted_byte( len, packet_haddr, packet_ptr );
                         break;
                     case NETTRAMON_PRO_ICMP:
-                        print_len = sprintf( tmp, "------ICMP Packet-----\nFrom: %s\t\t : ",inet_ntoa(packet_ptr->ip_head->ip_src)  );
+                        print_len = sprintf( tmp, "------ICMP Packet-----\nFrom: %s \n",    inet_ntoa(packet_ptr->ip_head->ip_src)  );
                         strncat( json_packet_content, tmp, print_len );
-                        print_len = sprintf( tmp, "%s\t : ",                              inet_ntoa(packet_ptr->ip_head->ip_dst)  );
+                        print_len = sprintf( tmp, "To:   %s\n",                             inet_ntoa(packet_ptr->ip_head->ip_dst)  );
                         strncat( json_packet_content, tmp, print_len );
-                        //print_tainted_byte( len, packet_haddr, packet_ptr );
                         break;
                     case NETTRAMON_PRO_UNKNOWN:
                     default:

--- a/ext/dba/dba_taint.h
+++ b/ext/dba/dba_taint.h
@@ -3,10 +3,37 @@
 
 #include "dba.h"
 
+/// Set the sample tainted by given taint tag
+/// 
+///     \param  ctx             current task's dba_context pointer
+///
+/// Return 0 for success
 extern int set_sample_tainted( dba_context* ctx );
+
+/// TODO:
+///
+/// Return
 extern int check_mbr_tainted( dba_context* ctx );
+
+/// Collect tainted files by the taint tag used in the task 
+/// 
+///     \param  ctx             current task's dba_context pointer
+///
+/// Return 0 for success
 extern int enum_tainted_file( dba_context* ctx );
+
+/// TODO: 
+///
+/// Return
 extern int enum_tainted_registry( dba_context* ctx );
+
+/// Check whether cpatured packet is tainted
+/// 
+///     \param  len             length of captured packet
+///     \param  packet_haddr    the physical address of captured packet
+///     \param  ctx             current task's dba_context pointer
+///
+/// Return None
 extern void* tainted_packet_cb( size_t len, haddr_t packet_haddr, void* ctx );
 
 #endif

--- a/ext/dba/dba_taint.h
+++ b/ext/dba/dba_taint.h
@@ -7,5 +7,6 @@ extern int set_sample_tainted( dba_context* ctx );
 extern int check_mbr_tainted( dba_context* ctx );
 extern int enum_tainted_file( dba_context* ctx );
 extern int enum_tainted_registry( dba_context* ctx );
+extern void* tainted_packet_cb( size_t len, haddr_t packet_haddr, void* ctx );
 
 #endif

--- a/ext/nettramon/nettramon.c
+++ b/ext/nettramon/nettramon.c
@@ -334,6 +334,7 @@ int nettramon_set_cb( void*(*cb)( size_t, haddr_t, void* ), void* cb_arg ) {
 
     return next_uid;
 }
+
 /* Delete the call back function with the input uid */
 /* Return 0 for success or 1 for fail */
 int nettramon_delete_cb( int uid ) {
@@ -383,7 +384,7 @@ int nettramon_disable_cb( int uid ) {
     
     ntm->cb_arr[uid]->enabled = FALSE;
 
-    pthread_rwlock_wrlock( &ntm->rwlock );
+    pthread_rwlock_unlock( &ntm->rwlock );
     return 0;
 }
 

--- a/ext/nettramon/nettramon.c
+++ b/ext/nettramon/nettramon.c
@@ -25,91 +25,67 @@
 #include "nettramon.h"
 #include "libpcap/pcap/pcap.h"
 
-static MBA_NETTRAMON_PRO   protocol_type  = NETTRAMON_PRO_UNKNOWN;
-static Monitor*            local_mon      = NULL;
-static struct bpf_program* filter  = NULL;
-static bool                status  = 0;
-
-struct file_ptr {
-    FILE* all_file;
-    FILE* tcp_file;
-    FILE* udp_file;
-    FILE* icmp_file;
-};
-typedef struct file_ptr file_ptr;
-
-struct path_buffer {
-    bool has_set;
-    char all_file_path_buf  [SZ_NETTRAMON_PATH_LENGTH];
-    char tcp_file_path_buf  [SZ_NETTRAMON_PATH_LENGTH];
-    char udp_file_path_buf  [SZ_NETTRAMON_PATH_LENGTH];
-    char icmp_file_path_buf [SZ_NETTRAMON_PATH_LENGTH];
-};
-typedef struct path_buffer path_buffer;
-
-file_ptr fp[1] = {};
-path_buffer pb[1] = {};
-
+ntm_context ntm[1] = { { 0 } };
 
 /// Static Functions
 
 // Reset file pointer
 // Return None
 static void nettramon_clear_filter( void ) {
-    free( filter );
-    filter = NULL;
+    free( ntm->filter );
+    ntm->filter = NULL;
 }
 
 // Reset file pointer
 // Return None
 static void nettramon_clear_file_path( void ) {
-    bzero( pb, sizeof(path_buffer) );
+    bzero( ntm->pb, sizeof(path_buffer) );
 }
 
 // Clean up all the variables
 // Return none
 static void nettramon_cleanup ( void ) {
 
-    local_mon = NULL;
-    if ( fp->all_file != NULL )
-        fclose( fp->all_file );
-    if ( fp->tcp_file != NULL )
-        fclose( fp->tcp_file );
-    if ( fp->udp_file != NULL )
-        fclose( fp->udp_file );
-    if ( fp->icmp_file != NULL )
-        fclose( fp->icmp_file );
-    bzero( fp, sizeof( file_ptr ) );
+    ntm->local_mon = NULL;
+    if ( ntm->fp->all_file != NULL )
+        fclose( ntm->fp->all_file );
+    if ( ntm->fp->tcp_file != NULL )
+        fclose( ntm->fp->tcp_file );
+    if ( ntm->fp->udp_file != NULL )
+        fclose( ntm->fp->udp_file );
+    if ( ntm->fp->icmp_file != NULL )
+        fclose( ntm->fp->icmp_file );
+    bzero( ntm->fp, sizeof( file_ptr ) );
 }
 
 // Resume written files
 // Return 0 for success, 1 for file
 static unsigned int nettramon_file_path_resume( void ) {
     
-    if ( pb->all_file_path_buf[0] != '\0' ) {
-        fp->all_file = fopen( pb->all_file_path_buf , "a" );
-        if ( fp->all_file == NULL ) {
+    if ( ntm->pb->all_file_path_buf[0] != '\0' ) {
+        ntm->fp->all_file = fopen( ntm->pb->all_file_path_buf , "a" );
+        if ( ntm->fp->all_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
     }
-    if ( pb->tcp_file_path_buf[0] != '\0' ) {
-        fp->tcp_file = fopen( pb->tcp_file_path_buf , "a" );
-        if ( fp->tcp_file == NULL ) {
+    if ( ntm->pb->tcp_file_path_buf[0] != '\0' ) {
+        ntm->fp->tcp_file = fopen( ntm->pb->tcp_file_path_buf , "a" );
+        if ( ntm->fp->tcp_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
     }
-    if ( pb->udp_file_path_buf[0] != '\0' ) {
-        fp->udp_file = fopen( pb->udp_file_path_buf , "a" );
-        if ( fp->udp_file == NULL ) {
+    if ( ntm->pb->udp_file_path_buf[0] != '\0' ) {
+        ntm->fp->udp_file = fopen( ntm->pb->udp_file_path_buf , "a" );
+        if ( ntm->fp->udp_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
     }
-    if ( pb->icmp_file_path_buf[0] != '\0' ) {
-        fp->icmp_file = fopen( pb->icmp_file_path_buf , "a" );
-        if ( fp->icmp_file == NULL ) {
+    if ( ntm->pb->icmp_file_path_buf[0] != '\0' ) {
+        ntm->fp->icmp_file = fopen( ntm->pb->icmp_file_path_buf , "a" );
+        if ( ntm->fp->icmp_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
@@ -123,32 +99,32 @@ static void nettramon_printf( const char* fmt, ... ) {
     
     va_list args;
 
-    if ( local_mon != NULL && fp->all_file == NULL && fp->tcp_file == NULL && fp->udp_file == NULL && fp->icmp_file == NULL ) {
+    if ( ntm->local_mon != NULL && ntm->fp->all_file == NULL && ntm->fp->tcp_file == NULL && ntm->fp->udp_file == NULL && ntm->fp->icmp_file == NULL ) {
         va_start( args, fmt );
-        monitor_vprintf( local_mon, fmt, args );
+        monitor_vprintf( ntm->local_mon, fmt, args );
         va_end( args );
         return;
     }
 
-    switch( protocol_type ) {
+    switch( ntm->protocol_type ) {
         case NETTRAMON_PRO_TCP :
-            if ( fp->tcp_file != NULL ) {
+            if ( ntm->fp->tcp_file != NULL ) {
                 va_start( args, fmt );
-                vfprintf( fp->tcp_file, fmt, args );
+                vfprintf( ntm->fp->tcp_file, fmt, args );
                 va_end( args );
             }
             break;
         case NETTRAMON_PRO_UDP :
-            if ( fp->udp_file != NULL ) {
+            if ( ntm->fp->udp_file != NULL ) {
                 va_start( args, fmt );
-                vfprintf( fp->udp_file, fmt, args );
+                vfprintf( ntm->fp->udp_file, fmt, args );
                 va_end( args );
             }
             break;
         case NETTRAMON_PRO_ICMP :
-            if ( fp->icmp_file != NULL ) {
+            if ( ntm->fp->icmp_file != NULL ) {
                 va_start( args, fmt );
-                vfprintf( fp->icmp_file, fmt, args );
+                vfprintf( ntm->fp->icmp_file, fmt, args );
                 va_end( args );
             }
             break;
@@ -157,9 +133,9 @@ static void nettramon_printf( const char* fmt, ... ) {
             break;
     }
 
-    if ( protocol_type != NETTRAMON_PRO_UNKNOWN && fp->all_file != NULL ) {
+    if ( ntm->protocol_type != NETTRAMON_PRO_UNKNOWN && ntm->fp->all_file != NULL ) {
         va_start( args, fmt );
-        vfprintf( fp->all_file, fmt, args );
+        vfprintf( ntm->fp->all_file, fmt, args );
         va_end( args );
     }
 
@@ -251,34 +227,37 @@ static void print_payload( const u_char *payload, int len ) {
 // return 0 for success, 1 for fail
 static int print_packet( packet_info* packet ) {
    
-    protocol_type = packet->packet_protocol;
+    ntm->protocol_type = packet->packet_protocol;
 
     switch( packet->packet_protocol ) {
         case NETTRAMON_PRO_TCP :
             nettramon_printf("\n==========Protocol: TCP==========\n");
             /* print source and destination IP addresses and used port */
-            nettramon_printf("From: %s\t\t%d\n", inet_ntoa(packet->ip_head->ip_src), packet->tcp_head->th_sport);
-            nettramon_printf("To:   %s\t\t%d\n", inet_ntoa(packet->ip_head->ip_dst), packet->tcp_head->th_dport);
-            print_payload( (const u_char *)packet->payload, packet->len );
-            nettramon_printf("\n==========Protocol: TCP==========\n");
+            nettramon_printf("From: %s\t\t",    inet_ntoa(packet->ip_head->ip_src));
+            nettramon_printf("%d\n",            packet->tcp_head->th_sport);
+            nettramon_printf("To:   %s\t",      inet_ntoa(packet->ip_head->ip_dst));
+            nettramon_printf("%d\n",            packet->tcp_head->th_dport);
+            /* print packet payload */
+            print_payload( (const u_char*)packet->payload, packet->len );
             break;
         case NETTRAMON_PRO_UDP :
             nettramon_printf("\n==========Protocol: UDP==========\n");
             /* print source and destination IP addresses and used port */
-            nettramon_printf("From: %s\t\t%d\n", inet_ntoa(packet->ip_head->ip_src), packet->udp_head->uh_sport);
-            nettramon_printf("To:   %s\t\t%d\n", inet_ntoa(packet->ip_head->ip_dst), packet->udp_head->uh_dport);
-            print_payload( (const u_char *)packet->payload, packet->len );
-            nettramon_printf("\n==========Protocol: UDP==========\n");
+            nettramon_printf("From: %s\t\t",    inet_ntoa(packet->ip_head->ip_src));
+            nettramon_printf("%d\n",            packet->udp_head->uh_sport);
+            nettramon_printf("To:   %s\t",      inet_ntoa(packet->ip_head->ip_dst));
+            nettramon_printf("%d\n",            packet->udp_head->uh_dport);
+            /* print packet payload */
+            print_payload( (const u_char*)packet->payload, packet->len );
             break;
         case NETTRAMON_PRO_ICMP :
             nettramon_printf("\n==========Protocol: ICMP==========\n");
-            nettramon_printf("From: %s\n", inet_ntoa(packet->ip_head->ip_src));
-            nettramon_printf("To:   %s\n", inet_ntoa(packet->ip_head->ip_dst));
-            print_payload( (const u_char *)packet->payload, packet->len );
-            nettramon_printf("\n==========Protocol: ICMP==========\n");
+            nettramon_printf("From: %s\n",      inet_ntoa(packet->ip_head->ip_src));
+            nettramon_printf("To:   %s\n",      inet_ntoa(packet->ip_head->ip_dst));
+            /* print packet payload */
+            print_payload( (const u_char*)packet->payload, packet->len );
             break;
         case NETTRAMON_PRO_UNKNOWN :
-            //nettramon_printf("\n==========Protocol: UNKNOWN==========\n");
             //nettramon_printf("\n==========Protocol: UNKNOWN==========\n");
         default :
             free(packet);
@@ -288,42 +267,137 @@ static int print_packet( packet_info* packet ) {
     return 0;
 }
 
+// Clear input packet_info structure
+// Return none
+static void clear_packet_info ( packet_info* in ) {
+
+    in->packet_protocol = NETTRAMON_PRO_UNKNOWN;
+    in->eth_head = NULL;
+    in->ip_head = NULL;
+    in->tcp_head = NULL;
+    in->udp_head = NULL;
+    in->icmp_head = NULL;
+    in->payload = NULL;
+    in->len = 0;
+
+}
+
+static int get_nettramon_cb_uid ( void ) {
+    
+    int i;
+
+    for ( i = 0; i < SZ_NETTRAMON_MAX_CB; i++ )
+        if ( ntm->cb_arr[i] == NULL )
+            break;
+
+    if ( i == SZ_NETTRAMON_MAX_CB )
+        return -1;
+
+    return i;
+}
+
+
 /// Publuc APIs
 
 // NetTraMon is active or not
 // Return boolean, True for positive and False for negative
 bool nettramon_is_active( void ) {
 
-    return status;
+    return ntm->status;
 
+}
+
+// Set the call back function for further analysis according to the "action" argument
+// Return 0 for success, 1 for fail
+int nettramon_set_cb( void*(*cb)( size_t, haddr_t, void* ), void* cb_arg ) {
+
+    int next_uid = get_nettramon_cb_uid();
+
+    if ( cb == NULL || next_uid == -1 ) 
+        return 1;
+
+    nettramon_cb* tmp = (nettramon_cb*)calloc( 1, sizeof(nettramon_cb) );
+    tmp->uid      = next_uid;
+    tmp->enabled  = TRUE;
+    tmp->user_cb  = cb;
+    tmp->cb_arg   = cb_arg;
+    tmp->next     = NULL;
+
+    LL_APPEND( ntm->cb_list, tmp );
+
+    // Add cb to array
+    ntm->cb_arr[next_uid] = tmp;
+
+    return next_uid;
+}
+/* Delete the call back function with the input uid */
+/* Return 0 for success or 1 for fail */
+int nettramon_delete_cb( int uid ) {
+    
+    if ( ntm->cb_arr[uid] == NULL )
+        return 1;
+
+    nettramon_cb* target = NULL;
+    nettramon_cb* tmp = NULL;
+
+    // Find the target cb
+    LL_FOREACH_SAFE( ntm->cb_list, target, tmp ) { 
+        if ( target->uid == uid )
+            LL_DELETE( ntm->cb_list, target );
+    }
+
+    return 0;
+}
+
+/* Enable the call back function with the input uid */
+/* Return 0 for success or 1 for fail */
+int nettramon_enable_cb( int uid ) {
+    
+    if ( ntm->cb_arr[uid] == NULL )
+        return 1;
+    
+    ntm->cb_arr[uid]->enabled = TRUE;
+    return 0;
+}
+
+/* Disable the call back function with the input uid */
+/* Return 0 for success or 1 for fail */
+int nettramon_disable_cb( int uid ) {
+    
+    if ( ntm->cb_arr[uid] == NULL )
+        return 1;
+    
+    ntm->cb_arr[uid]->enabled = FALSE;
+    return 0;
 }
 
 // Parser for printing result directly on the monitor or the files
 // Return 0 for success, 1 for fail
-int nettramon_parse_buffer( const u_char* buf, size_t len, void(*user_cb)(u_char*, size_t) ) {
+int nettramon_packet_capture( const u_char* buf, size_t len, haddr_t packet_haddr ) {
     
     if ( !nettramon_is_active() )
         return 0;
 
-    if ( filter != NULL )
-        if ( !bpf_filter( filter->bf_insns, (const u_char*)buf, len, len ) )
+    if ( ntm->filter != NULL )
+        if ( !bpf_filter( ntm->filter->bf_insns, (const u_char*)buf, len, len ) )
             return 0;
-    
-    if ( user_cb != NULL ) {
-        u_char* buf_cb = (u_char *)malloc( len * sizeof(u_char) );
-        memcpy( buf_cb, buf, len );
-        user_cb( buf_cb, len );
-    }
-    else {
-        packet_info* packet;
-        packet = nettramon_packet_parse( buf, len );
-        if ( packet == NULL ) {
-            return 1;
+ 
+    if ( ntm->cb_list != NULL ) {
+        nettramon_cb* tmp = ntm->cb_list;
+        while( tmp != NULL ) {
+            tmp->user_cb( len, packet_haddr, tmp->cb_arg );
+            tmp = tmp->next;
         }
+    }
+
+    if ( ntm->local_mon != NULL || ntm->fp->all_file != NULL || ntm->fp->tcp_file != NULL || ntm->fp->udp_file != NULL || ntm->fp->icmp_file != NULL ) {
+        packet_info* packet = (packet_info*)calloc( 1, sizeof(packet_info) );
+        if ( nettramon_packet_parse( buf, len, packet ) != 0 )
+            return 1;
         return print_packet( packet );
     }
 
-    return 0;    
+    return 0;
 }
 
 // Start to print out the packet
@@ -333,22 +407,22 @@ unsigned int nettramon_start ( Monitor* mon ) {
     if ( nettramon_is_active() )
         return 0;
 
-    if ( pb->has_set ) {
+    if ( ntm->pb->has_set ) {
         if ( nettramon_file_path_resume() )
             return 1;
     }
 
-    if ( fp->all_file == NULL && fp->tcp_file == NULL && fp->udp_file == NULL && fp->icmp_file == NULL ) {
-        if ( mon != NULL ) {
-            local_mon = mon;
-            status = TRUE;
+    if ( ntm->fp->all_file == NULL && ntm->fp->tcp_file == NULL && ntm->fp->udp_file == NULL && ntm->fp->icmp_file == NULL ) {
+        if ( mon != NULL || ntm->cb_list != NULL ) {
+            ntm->local_mon = mon;
+            ntm->status = TRUE;
             return 0;
         }
         return 2;
     }
     else {
-        local_mon = NULL;
-        status = TRUE;
+        ntm->local_mon = NULL;
+        ntm->status = TRUE;
         return 1;
     }
     
@@ -359,9 +433,9 @@ unsigned int nettramon_start ( Monitor* mon ) {
 unsigned int nettramon_stop ( void ) {
 
     nettramon_cleanup();
-    status = 0;
+    ntm->status = 0;
 
-    if ( local_mon == NULL )
+    if ( ntm->local_mon == NULL )
         return 0;
     return 1;
     
@@ -372,52 +446,52 @@ unsigned int nettramon_stop ( void ) {
 unsigned int nettramon_set_file_path ( const char* all_file_path, const char* tcp_file_path, const char* udp_file_path, const char* icmp_file_path ) {
 
     if ( !(strlen(all_file_path) == 1 && all_file_path[0] == 'N') ) {
-        strncpy( pb->all_file_path_buf, all_file_path, SZ_NETTRAMON_PATH_LENGTH );
-        fp->all_file = fopen( pb->all_file_path_buf , "w" );
-        if ( fp->all_file == NULL ) {
+        strncpy( ntm->pb->all_file_path_buf, all_file_path, SZ_NETTRAMON_PATH_LENGTH );
+        ntm->fp->all_file = fopen( ntm->pb->all_file_path_buf , "w" );
+        if ( ntm->fp->all_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
-        pb->has_set = TRUE;
+        ntm->pb->has_set = TRUE;
     }
     else
-        fp->all_file = NULL;
+        ntm->fp->all_file = NULL;
 
     if ( !(strlen(tcp_file_path) == 1 && tcp_file_path[0] == 'N') ) {
-        strncpy( pb->tcp_file_path_buf, tcp_file_path, SZ_NETTRAMON_PATH_LENGTH );
-        fp->tcp_file = fopen( pb->tcp_file_path_buf , "w" );
-        if ( fp->tcp_file == NULL ) {
+        strncpy( ntm->pb->tcp_file_path_buf, tcp_file_path, SZ_NETTRAMON_PATH_LENGTH );
+        ntm->fp->tcp_file = fopen( ntm->pb->tcp_file_path_buf , "w" );
+        if ( ntm->fp->tcp_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
-        pb->has_set = TRUE;
+        ntm->pb->has_set = TRUE;
     }
     else
-        fp->tcp_file = NULL;
+        ntm->fp->tcp_file = NULL;
 
     if ( !(strlen(udp_file_path) == 1 && udp_file_path[0] == 'N') ) {
-        strncpy( pb->udp_file_path_buf, udp_file_path, SZ_NETTRAMON_PATH_LENGTH );
-        fp->udp_file = fopen( pb->udp_file_path_buf , "w" );
-        if ( fp->udp_file == NULL ) {
+        strncpy( ntm->pb->udp_file_path_buf, udp_file_path, SZ_NETTRAMON_PATH_LENGTH );
+        ntm->fp->udp_file = fopen( ntm->pb->udp_file_path_buf , "w" );
+        if ( ntm->fp->udp_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
-        pb->has_set = TRUE;
+        ntm->pb->has_set = TRUE;
     }
     else
-        fp->udp_file = NULL;
+        ntm->fp->udp_file = NULL;
 
     if ( !(strlen(icmp_file_path) == 1 && icmp_file_path[0] == 'N') ) {
-        strncpy( pb->icmp_file_path_buf, icmp_file_path, SZ_NETTRAMON_PATH_LENGTH );
-        fp->icmp_file = fopen( pb->icmp_file_path_buf , "w" );
-        if ( fp->icmp_file == NULL ) {
+        strncpy( ntm->pb->icmp_file_path_buf, icmp_file_path, SZ_NETTRAMON_PATH_LENGTH );
+        ntm->fp->icmp_file = fopen( ntm->pb->icmp_file_path_buf , "w" );
+        if ( ntm->fp->icmp_file == NULL ) {
             nettramon_clear_file_path();
             return 1;
         }
-        pb->has_set = TRUE;
+        ntm->pb->has_set = TRUE;
     }
     else
-        fp->icmp_file = NULL;
+        ntm->fp->icmp_file = NULL;
 
     return 0;
     
@@ -434,10 +508,10 @@ unsigned int nettramon_reset_file_path ( void ) {
 // Return 0 for success, 1 for fail
 unsigned int nettramon_set_filter ( const char* filter_string ) {
 
-    filter = ( struct bpf_program *)malloc( sizeof( struct bpf_program ) );
+    ntm->filter = ( struct bpf_program *)malloc( sizeof( struct bpf_program ) );
 
-    pcap_compile_nopcap( 1500, DLT_EN10MB, filter, filter_string, 0, 0);
-    if ( filter == NULL )
+    pcap_compile_nopcap( 1500, DLT_EN10MB, ntm->filter, filter_string, 0, 0);
+    if ( ntm->filter == NULL )
         return 1;
     return 0;
 }
@@ -450,121 +524,106 @@ unsigned int nettramon_reset_filter ( void ) {
 }
 
 // Packet Parse
-// Return struct packet_info* for success, and NULL for fail to parse the packet buf
-packet_info* nettramon_packet_parse ( const u_char* buf, size_t len ) {
+// Return 0 for success, 1 for fail
+int nettramon_packet_parse ( const u_char* buf, size_t len, packet_info* user_info ) {
 
-    packet_info* packet;
+    if ( user_info == NULL )
+        return 1;
+
     int size_ip, size_tcp;
     size_t check_len;
-
-    packet = (packet_info*)calloc( 1, sizeof(packet_info) );
     check_len = len;
     
     /* ETHERNET HEAD */
     if ( check_len < SZ_ETHERNET_H ) {
-        free(packet);
-        return NULL;
+        clear_packet_info( user_info );
+        return 1;
     }
-    packet->eth_head = (ntm_ethernet*)(buf);
+    user_info->eth_head = (ntm_ethernet*)(buf);
 
     /* Move to IP header */
     check_len -= SZ_ETHERNET_H;
 
     /* IP HEAD and PROTOCOL */
     if ( check_len < SZ_IP_H ) {
-        free(packet);
-        return NULL;
+        clear_packet_info( user_info );
+        return 1;
     }
-    packet->ip_head = (ntm_ip*)(buf + SZ_ETHERNET_H);
-    size_ip = IP_HL(packet->ip_head)*4;
-    if (size_ip < 20) {
-        free(packet);
-        return NULL;
-    }
-    if ( check_len < size_ip ) {
-        free(packet);
-        return NULL;
+    user_info->ip_head = (ntm_ip*)(buf + SZ_ETHERNET_H);
+    size_ip = IP_HL(user_info->ip_head)*4;
+    if ( size_ip < 20 ||  check_len < size_ip ) {
+        clear_packet_info( user_info );
+        return 1;
     }
 
     /* Move to next header */
     check_len -= size_ip;
 
-    switch( packet->ip_head->ip_p ) {
+    switch( user_info->ip_head->ip_p ) {
         case IPPROTO_TCP:
             if ( check_len < SZ_TCP_H ) {
-                free(packet);
-                return NULL;
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->tcp_head = (ntm_tcp*)(buf + SZ_ETHERNET_H + size_ip);
-            size_tcp = TH_OFF(packet->tcp_head)*4;
-            if ( size_tcp < SZ_TCP_H ) {
-                free(packet);
-                return NULL;
+            user_info->tcp_head = (ntm_tcp*)(buf + SZ_ETHERNET_H + size_ip);
+            size_tcp = TH_OFF(user_info->tcp_head)*4;
+            if ( size_tcp < SZ_TCP_H || check_len < size_tcp ) {
+                clear_packet_info( user_info );
+                return 1;
             }
-            if ( check_len < size_tcp ) {
-                free(packet);
-                return NULL;
-            }
-            packet->packet_protocol = NETTRAMON_PRO_TCP;
-            packet->payload = (u_char*)(buf + SZ_ETHERNET_H + size_ip + size_tcp);
+            user_info->packet_protocol = NETTRAMON_PRO_TCP;
+            user_info->payload = (u_char*)(buf + SZ_ETHERNET_H + size_ip + size_tcp);
             check_len -= size_tcp;
-            packet->len = ntohs(packet->ip_head->ip_len) - (size_ip + size_tcp);
-            if ( check_len != packet->len ) {
-                free(packet);
-                return NULL;
+            user_info->len = ntohs(user_info->ip_head->ip_len) - (size_ip + size_tcp);
+            if ( check_len != user_info->len ) {
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->udp_head = NULL;
-            packet->icmp_head = NULL;
-            return packet;
+            user_info->udp_head = NULL;
+            user_info->icmp_head = NULL;
+            return 0;
         case IPPROTO_UDP:
             if ( check_len < SZ_UDP_H ) {
-                free(packet);
-                return NULL;
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->udp_head = (ntm_udp*)(buf + SZ_ETHERNET_H + size_ip);
-            if ( check_len != ntohs(packet->udp_head->uh_leng) ) {
-                free(packet);
-                return NULL;
+            user_info->udp_head = (ntm_udp*)(buf + SZ_ETHERNET_H + size_ip);
+            if ( check_len != ntohs(user_info->udp_head->uh_leng) ) {
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->packet_protocol = NETTRAMON_PRO_UDP;
-            packet->payload = (u_char*)(buf + SZ_ETHERNET_H + size_ip + SZ_UDP_H);
-            packet->len = ntohs(packet->ip_head->ip_len) - (size_ip + SZ_UDP_H);
+            user_info->packet_protocol = NETTRAMON_PRO_UDP;
+            user_info->payload = (u_char*)(buf + SZ_ETHERNET_H + size_ip + SZ_UDP_H);
+            user_info->len = ntohs(user_info->ip_head->ip_len) - (size_ip + SZ_UDP_H);
             check_len -= SZ_UDP_H;
-            packet->len = ntohs(packet->ip_head->ip_len) - (size_ip + SZ_UDP_H);
-            if ( check_len != packet->len ) {
-                free(packet);
-                return NULL;
+            user_info->len = ntohs(user_info->ip_head->ip_len) - (size_ip + SZ_UDP_H);
+            if ( check_len != user_info->len ) {
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->tcp_head = NULL;
-            packet->icmp_head = NULL;
-            return packet;
+            user_info->tcp_head = NULL;
+            user_info->icmp_head = NULL;
+            return 0;
         case IPPROTO_ICMP:
             if ( check_len < SZ_ICMP_H ) {
-                free(packet);
-                return NULL;
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->icmp_head = (ntm_icmp*)(buf + SZ_ETHERNET_H + size_ip);
-            packet->packet_protocol = NETTRAMON_PRO_ICMP; 
-            packet->payload = (u_char*)(buf + SZ_ETHERNET_H + size_ip + SZ_ICMP_H);
-            packet->len = ntohs(packet->ip_head->ip_len) - (size_ip + SZ_ICMP_H);
+            user_info->icmp_head = (ntm_icmp*)(buf + SZ_ETHERNET_H + size_ip);
+            user_info->packet_protocol = NETTRAMON_PRO_ICMP; 
+            user_info->payload = (u_char*)(buf + SZ_ETHERNET_H + size_ip + SZ_ICMP_H);
+            user_info->len = ntohs(user_info->ip_head->ip_len) - (size_ip + SZ_ICMP_H);
             check_len -= SZ_ICMP_H;
-            if ( check_len != packet->len ) {
-                free(packet);
-                return NULL;
+            if ( check_len != user_info->len ) {
+                clear_packet_info( user_info );
+                return 1;
             }
-            packet->tcp_head = NULL;
-            packet->udp_head = NULL;
-            return packet;
+            user_info->tcp_head = NULL;
+            user_info->udp_head = NULL;
+            return 0;
         default:
-            packet->packet_protocol = NETTRAMON_PRO_UNKNOWN;
-            packet->eth_head = NULL;
-            packet->ip_head = NULL;
-            packet->tcp_head = NULL;
-            packet->udp_head = NULL;
-            packet->icmp_head = NULL;
-            packet->payload = NULL;
-            packet->len = 0;
-            return packet;
+            clear_packet_info( user_info );
+            return 1;
     }
 
 }

--- a/ext/nettramon/nettramon.h
+++ b/ext/nettramon/nettramon.h
@@ -239,11 +239,11 @@ unsigned int nettramon_set_filter                ( const char* );
 /* Clear the set filter */
 /* Return 0 for suceess, or 1 for fail */
 unsigned int nettramon_reset_filter              ( void );
-/*------ The upper APIs are for the nettramon module operations ------*/
 
 /* Parse the input u_char array's content as a packet */
 /* Argument packet_info* would be set with pointers of all parts in the u_char array if parsing successfully */
 /* Return 0 for suceess, or 1 for fail */
 int          nettramon_packet_parse              ( const u_char*, size_t, packet_info* );
+/*------ The upper APIs are for the nettramon module operations ------*/
 
 #endif

--- a/ext/nettramon/nettramon.h
+++ b/ext/nettramon/nettramon.h
@@ -180,7 +180,8 @@ struct ntm_context {
     nettramon_cb*       cb_list;
     // call back functoin array
     nettramon_cb*       cb_arr[SZ_NETTRAMON_MAX_CB];
-
+    // read-write lock to protect the internal data
+    pthread_rwlock_t    rwlock;
 };
 typedef struct ntm_context ntm_context;
 

--- a/monitor.c
+++ b/monitor.c
@@ -5572,6 +5572,7 @@ void *mba_mon_get_cpu( void ) {
     return mon_get_cpu();
 }
 
+// The following functions should check the setting mode by API
 void mba_readline_start( Monitor* mon, const char *prompt, int read_password,
                          ReadLineFunc *readline_func, void *opaque) {
 #if defined(CONFIG_DBA)

--- a/monitor.c
+++ b/monitor.c
@@ -5574,10 +5574,24 @@ void *mba_mon_get_cpu( void ) {
 
 void mba_readline_start( Monitor* mon, const char *prompt, int read_password,
                          ReadLineFunc *readline_func, void *opaque) {
+#if defined(CONFIG_DBA)
+    if ( !do_dba_config_file_setting() ) {
+        readline_start( mon->rs, prompt, read_password, readline_func, opaque );
+    }
+#endif
+#if !defined(CONFIG_DBA)
     readline_start( mon->rs, prompt, read_password, readline_func, opaque );
+#endif
 }
 
 void mba_readline_show_prompt( Monitor* mon ) {
+#if defined(CONFIG_DBA)
+    if ( !do_dba_config_file_setting() ) {
+        readline_show_prompt( mon->rs );
+    }
+#endif
+#if !defined(CONFIG_DBA)
     readline_show_prompt( mon->rs );
+#endif
 }
 


### PR DESCRIPTION
NetTraMon Module Update
1. Add call-back function list and array to allow users to register their own call-back function dealing with captured packets.
2. Add nettramon_parse_packet API and packet_info structure to module so as to offer packet parsing operation.
3. Assemble the global variables of NTM into a ntm_context global structure.
4. Modify the way for printing out the packet content.
5. Rename API nettramon_parse_buffer by nettramon_packet_capture.
6. Add read-write lock to enhance thread-safety for NetTraMon
7. Fix bug in read_write lock of NTM.

DBA Module
1. Add tainted_packet_cb to ext/dba/dba_taint.c in order to parse tainted packets and append into task's result.
2. Start NTM by API in dba_internal_main via defined CONFIG_DIFT.
3. Assemble import, sync, invoke, sync operations into invoke_sample function due to compile error caused by checking whether a task needs taint ability.
4. Add API dba_set_monitor and put monitor pointer into dba_context so as to let task show message after finishing.
5. DBA can read config file containing setting information in JSON format (config file is optional).
6. Add global variable set_by_config to dba-commands.c to distinguish the setting method of task.
7. Fix bug in printing tainted packet.

Other modification:
Configure file of QEMU
1. Add --disable-[module name] in order to disable a module for convenience.