### PR TITLE
Tracer Ability in DBA and TRACER, OBHOOK Updates

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -219,11 +219,11 @@ endif
 ifdef CONFIG_DBA
 all-obj-y += ../ext/dba/dba.o
 all-obj-y += ../ext/dba/dba_taint.o
-all-obj-y += ../ext/dba/dba_syscall.o
+all-obj-y += ../ext/dba/dba_tracer.o
 all-obj-y += ../ext/dba/dba-commands.o
 ../ext/dba/dba.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
 ../ext/dba/dba_taint.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
-../ext/dba/dba_syscall.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
+../ext/dba/dba_tracer.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
 ../ext/dba/dba-commands.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
 endif
 

--- a/Makefile.target
+++ b/Makefile.target
@@ -219,15 +219,22 @@ endif
 ifdef CONFIG_DBA
 all-obj-y += ../ext/dba/dba.o
 all-obj-y += ../ext/dba/dba_taint.o
+all-obj-y += ../ext/dba/dba_syscall.o
 all-obj-y += ../ext/dba/dba-commands.o
 ../ext/dba/dba.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
 ../ext/dba/dba_taint.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
+../ext/dba/dba_syscall.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
 ../ext/dba/dba-commands.o-cflags := -DHAVE_CONFIG_H -I$(SRC_PATH)/ext/tsk/sleuthkit
 endif
 
 ifdef CONFIG_TRACER
 all-obj-y += ../ext/tracer/tracer-commands.o
 all-obj-y += ../ext/tracer/tracer.o
+endif
+
+ifdef CONFIG_SYSTRACE
+all-obj-y += ../ext/systrace/systrace-commands.o
+all-obj-y += ../ext/systrace/systrace.o
 endif
 
 $(QEMU_PROG_BUILD): config-devices.mak

--- a/configure
+++ b/configure
@@ -347,6 +347,7 @@ obhook="no"
 nettramon="no"
 dba="no"
 tracer="no"
+systrace="no"
 #########################
 
 # parse CC options first
@@ -1171,6 +1172,9 @@ for opt do
     echo "NOTE: DBA relies on almost every MBA extension!!"
     dba="yes"
   ;;
+  --enable-systrace)
+    systrace="yes"
+  ;;
   --enable-mba-all)
     dift="yes"
     agent="yes"
@@ -1179,6 +1183,7 @@ for opt do
     obhook="yes"
     nettramon="yes"
     dba="yes"
+    systrace="yes"
     tracer="yes"
   ;;
   --disable-dift) dift="no"
@@ -1484,6 +1489,7 @@ Advanced options (experts only):
   --enable-tracer          enable tracer
   --enable-nettramon       enable Network Traffic Monitor
   --enable-dba             enable Dynamic Behavior Analyzer
+  --enable-systrace        enable System Call Tracing
   --enable-mba-all         enable all of the MBA features
 
 NOTE: The object files are built at the place where configure is launched
@@ -4557,6 +4563,7 @@ echo "Out-of-Box hook support           $obhook"
 echo "Tracer                            $tracer"
 echo "Network Traffic Monitor           $nettramon"
 echo "Dynamic behavior analysis support $dba"
+echo "System Call Tracing               $systrace"
 #########################
 
 if test "$sdl_too_old" = "yes"; then
@@ -5477,6 +5484,10 @@ if test "$tracer" = "yes"; then
   echo "CONFIG_TRACER=y" >> $config_target_mak
 fi
 
+if test "$systrace" = "yes"; then
+  echo "CONFIG_SYSTRACE=y" >> $config_host_mak
+  echo "CONFIG_SYSTRACE=y" >> $config_target_mak
+fi
 #########################
 
 # generate QEMU_CFLAGS/LDFLAGS for targets

--- a/disas.c
+++ b/disas.c
@@ -342,7 +342,7 @@ void target_disas(FILE *out, CPUArchState *env, target_ulong code,
            bit 16 indicates little endian.
     other targets - unused
  */
-void target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
+int target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
                   target_ulong size, int num_inst, int flags)
 {
     target_ulong pc;
@@ -455,8 +455,8 @@ void target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
     }
 
     for (pc = code, i=0 ; size > 0 && i < num_inst ; pc += count, size -= count, i++) {
-	fprintf(out, "0x" TARGET_FMT_lx ":  ", pc);
-	count = print_insn(pc, &s.info);
+        fprintf(out, "0x" TARGET_FMT_lx ":  ", pc);
+        count = print_insn(pc, &s.info);
 #if 0
         {
             int i;
@@ -469,9 +469,9 @@ void target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
             fprintf(out, " }");
         }
 #endif
-	fprintf(out, "\n");
-	if (count < 0)
-	    break;
+        fprintf(out, "\n");
+        if (count < 0)
+            break;
         if (size < count) {
             fprintf(out,
                     "Disassembler disagrees with translator over instruction "
@@ -480,6 +480,7 @@ void target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
             break;
         }
     }
+    return pc - code;
 }
 /* Disassemble this for me please... (debugging). */
 void disas(FILE *out, void *code, unsigned long size)

--- a/ext/Makefile.test
+++ b/ext/Makefile.test
@@ -7,9 +7,9 @@ GTEST_DIR   = $(GTEST_ROOT)/googletest
 GMOCK_DIR   = $(GTEST_ROOT)/googlemock
 GTEST_LIB   = $(EXT_DIR)/libgmock.a
 
-.PHONY: all dift tsk memfrs agent obhook
+.PHONY: all dift tsk memfrs agent obhook tracer
 
-all: $(GTEST_LIB) dift tsk memfrs agent obhook
+all: $(GTEST_LIB) dift tsk memfrs agent obhook tracer
 
 
 dift: $(GTEST_LIB)

--- a/ext/dba/dba-commands.c
+++ b/ext/dba/dba-commands.c
@@ -46,8 +46,6 @@ static void cb_dba_set_syscall( void* mon, const char* yn, void* opaque );
 static void cb_dba_set_taint_tag( void* mon, const char* yn, void* opaque );
 static void cb_dba_set_taint( void* mon, const char* yn, void* opaque );
 
-bool use_config_file = FALSE;
-
 static void show_dba_context_info( Monitor* mon, FILE* fp, const dba_context* ctx ) {
 
     if( (fp == NULL && mon == NULL) || ctx == NULL )
@@ -162,7 +160,7 @@ static void cb_dba_confirm( void* mon, const char* yn, void* opaque ) {
 // DBA - instruction tracer ?
 static void cb_dba_set_block_is_kernel( void* mon, const char* yn, void* opaque ) {
 
-    // goto block tracer
+    // goto confirm
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         dba_enable_block_tracer_is_kernel( (DBA_TID)opaque );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q12, 0, cb_dba_confirm, opaque );
@@ -170,7 +168,7 @@ static void cb_dba_set_block_is_kernel( void* mon, const char* yn, void* opaque 
         return;
     }
 
-    // goto block tracer
+    // goto confirm
     if( strcasecmp( "n", yn ) == 0 || strcasecmp( "no", yn ) == 0 ) {
         dba_disable_block_tracer_is_kernel( (DBA_TID)opaque );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q12, 0, cb_dba_confirm, opaque );
@@ -178,7 +176,7 @@ static void cb_dba_set_block_is_kernel( void* mon, const char* yn, void* opaque 
         return;
     }
 
-    // stay instruction tracer
+    // stay set in kernel
     mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q11, 0, cb_dba_set_block_is_kernel, opaque );
     mba_readline_show_prompt( mon );
 }
@@ -186,7 +184,7 @@ static void cb_dba_set_block_is_kernel( void* mon, const char* yn, void* opaque 
 // DBA - block tracer ?
 static void cb_dba_set_block( void* mon, const char* yn, void* opaque ) {
 
-    // goto confirm
+    // goto set in kernel 
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         dba_enable_block_tracer( (DBA_TID)opaque );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q11, 0, cb_dba_set_block_is_kernel, opaque );
@@ -203,7 +201,7 @@ static void cb_dba_set_block( void* mon, const char* yn, void* opaque ) {
         return;
     }
 
-    // stay syscall
+    // stay set block
     mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q10, 0, cb_dba_set_block, opaque );
     mba_readline_show_prompt( mon );
 }
@@ -211,7 +209,7 @@ static void cb_dba_set_block( void* mon, const char* yn, void* opaque ) {
 // DBA - instruction tracer ?
 static void cb_dba_set_instr_is_kernel( void* mon, const char* yn, void* opaque ) {
 
-    // goto block tracer
+    // goto set block
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         dba_enable_instr_tracer_is_kernel( (DBA_TID)opaque );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q10, 0, cb_dba_set_block, opaque );
@@ -219,7 +217,7 @@ static void cb_dba_set_instr_is_kernel( void* mon, const char* yn, void* opaque 
         return;
     }
 
-    // goto block tracer
+    // goto set block
     if( strcasecmp( "n", yn ) == 0 || strcasecmp( "no", yn ) == 0 ) {
         dba_disable_instr_tracer_is_kernel( (DBA_TID)opaque );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q10, 0, cb_dba_set_block, opaque );
@@ -227,7 +225,7 @@ static void cb_dba_set_instr_is_kernel( void* mon, const char* yn, void* opaque 
         return;
     }
 
-    // stay instruction tracer
+    // stay set in kernel 
     mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q9, 0, cb_dba_set_instr_is_kernel, opaque );
     mba_readline_show_prompt( mon );
 }
@@ -235,7 +233,7 @@ static void cb_dba_set_instr_is_kernel( void* mon, const char* yn, void* opaque 
 // DBA - instruction tracer ?
 static void cb_dba_set_instr( void* mon, const char* yn, void* opaque ) {
 
-    // goto block tracer
+    // goto set in kernel
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         dba_enable_instr_tracer( (DBA_TID)opaque );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q9, 0, cb_dba_set_instr_is_kernel, opaque );
@@ -243,7 +241,7 @@ static void cb_dba_set_instr( void* mon, const char* yn, void* opaque ) {
         return;
     }
 
-    // goto block tracer
+    // goto set block
     if( strcasecmp( "n", yn ) == 0 || strcasecmp( "no", yn ) == 0 ) {
         dba_disable_instr_tracer( (DBA_TID)opaque );
         dba_disable_instr_tracer_is_kernel( (DBA_TID)opaque );
@@ -268,7 +266,7 @@ static void cb_dba_set_global( void* mon, const char* yn, void* opaque ) {
         return;
     }
 
-    // stay syscall
+    // stay set global 
     mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q7, 0, cb_dba_set_global, opaque );
     mba_readline_show_prompt( mon );
 }
@@ -276,7 +274,7 @@ static void cb_dba_set_global( void* mon, const char* yn, void* opaque ) {
 // DBA - set structure ?
 static void cb_dba_set_structure( void* mon, const char* yn, void* opaque ) {
 
-    // goto next instruction tracer
+    // goto set global
     if( strlen( yn ) != 0 ) {
         dba_set_structure( (DBA_TID)opaque, yn );
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q7, 0, cb_dba_set_global, opaque );
@@ -284,7 +282,7 @@ static void cb_dba_set_structure( void* mon, const char* yn, void* opaque ) {
         return;
     }
 
-    // stay syscall
+    // stay set structure
     mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q6, 0, cb_dba_set_structure, opaque );
     mba_readline_show_prompt( mon );
 }
@@ -292,14 +290,14 @@ static void cb_dba_set_structure( void* mon, const char* yn, void* opaque ) {
 // DBA - tracer ?
 static void cb_dba_set_tracer( void* mon, const char* yn, void* opaque ) {
 
-    // goto instruction tracer
+    // goto set structure 
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q6, 0, cb_dba_set_structure, opaque );
         mba_readline_show_prompt( mon );
         return;
     }
 
-    // goto next instruction tracer
+    // goto confirm
     if( strcasecmp( "n", yn ) == 0 || strcasecmp( "no", yn ) == 0 ) {
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q12, 0, cb_dba_confirm, opaque );
         mba_readline_show_prompt( mon );
@@ -388,7 +386,7 @@ static void cb_dba_set_taint_packet( void* mon, const char* yn, void* opaque ) {
 // DBA - taint ?
 static void cb_dba_set_taint( void* mon, const char* yn, void* opaque ) {
 
-    // goto taint tag
+    // goto taint packet
     if( strcasecmp( "y", yn ) == 0 || strcasecmp( "yes", yn ) == 0 ) {
         mba_readline_start( (Monitor*)mon, PROMPT_DBA_Q2, 0, cb_dba_set_taint_packet, opaque );
         mba_readline_show_prompt( mon );
@@ -410,7 +408,7 @@ static void cb_dba_set_taint( void* mon, const char* yn, void* opaque ) {
 
 // Set dba enviroment via config file
 // Return 0 for success, 1 for fail
-static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void* opaque ) {
+static int dba_set_by_config ( Monitor* mon, const char* config_file_path, DBA_TID tid ) {
    
     json_object*    jo_config;
     json_object*    jo_object;
@@ -421,7 +419,9 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
         return 1;
     }
 
-    monitor_printf( mon, "====== Start to Enable Modules ======\n\n" );
+    monitor_printf( mon, "=====================================\n" );
+    monitor_printf( mon, "====== Start to Enable Modules ======\n" );
+    monitor_printf( mon, "=====================================\n" );
 
     // Enable modules
     if ( json_object_object_get_ex( (json_object*)jo_config, CONFIG_TAG_MODULE, &jo_object ) ) {
@@ -430,10 +430,10 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
         if ( json_object_object_get_ex( jo_object, CONFIG_TAG_AGENT, &jo_content ) ) {
             if ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_content ), CONFIG_TAG_Y ) == 0 ) {
                 do_win_init( mon, NULL );
-                monitor_printf( mon, "Enable Agent Successfully\n\n");
+                monitor_printf( mon, "Enable Agent Successfully\n");
             }
             else {
-                monitor_printf( mon, "Do nothing to Agent\n\n");
+                monitor_printf( mon, "Do nothing to Agent\n");
             }
         }
         // Enable DIFT
@@ -442,7 +442,7 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
                 //dift_enable();
             }
             else {
-                monitor_printf( mon, "Do nothing to Dift\n\n");
+                monitor_printf( mon, "Do nothing to Dift\n");
             }
         }
         // Enable Nettramon
@@ -498,17 +498,28 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
                         monitor_printf( mon, "Cannot get all the NTM files' tags, set with printing on the monitor\n");
                     }
                     nettramon_start( NULL );
-                    monitor_printf( mon, "Enable Nettramon Successfully\n\n");
+                    monitor_printf( mon, "Enable Nettramon Successfully\n");
+                }
+                else {
+                    monitor_printf( mon, "Do nothing to NTM\n");
                 }
             }
             else {
-                monitor_printf( mon, "Do nothing to NTM\n\n");
+                monitor_printf( mon, "Cannot get enable tag of NTM\n");
+                return 1;
             }
         }
 
     }
-    monitor_printf( mon, "====== Finish Enabling Modules ======\n\n" );
+    monitor_printf( mon, "=====================================\n" );
+    monitor_printf( mon, "====== Finish Enabling Modules ======\n" );
+    monitor_printf( mon, "=====================================\n\n" );
     // Modules
+
+    // DBA Abilities
+    monitor_printf( mon, "=====================================\n" );
+    monitor_printf( mon, "====== Start to Set Up DBA ==========\n" );
+    monitor_printf( mon, "=====================================\n" );
 
     // Set Taint
     if ( json_object_object_get_ex( (json_object*)jo_config, CONFIG_TAG_TAINT, &jo_object ) ) {
@@ -517,7 +528,26 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
             if ( ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_content ), CONFIG_TAG_Y ) == 0 ) ) {
                 // Get the taint tag
                 if ( json_object_object_get_ex( jo_object, CONFIG_TAG_TAINT_TAG, &jo_content ) ) {
-                    cb_dba_set_taint_tag( mon, json_object_get_string( jo_content ), opaque );
+
+                    CONTAMINATION_RECORD tag;
+                    long int tmp;
+                    char* end;
+                    char tag_str[10];
+
+                    strcpy( tag_str, json_object_get_string( jo_content ) );
+
+                    // invalidate taint tag
+                    tmp = strtol( tag_str, &end, 10 );
+                    if( *end != '\0' || tmp < 0x1 || tmp > 0x7f ) {
+                        monitor_printf( mon, "Invalid taint tag\n" );
+                        return 1;
+                    }
+
+                    tag = (CONTAMINATION_RECORD)(tmp & 0x00000000000000ff);
+
+                    if ( dba_enable_taint_analysis( tid, tag )!= 0 ) {
+                        monitor_printf( mon, "Set taint tag failed\n" );   
+                    }
                     monitor_printf( mon, "Set taint tag %s successfully\n", json_object_get_string( jo_content ) );
                 }
                 else {
@@ -527,18 +557,18 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
                 // Get the taint packet tag
                 if ( json_object_object_get_ex( jo_object, CONFIG_TAG_TAINT_PACKET, &jo_content ) ) {
                      if ( ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_content ), CONFIG_TAG_Y ) == 0 ) ) {
-                        cb_dba_set_taint_packet( mon, json_object_get_string( jo_content ), opaque );
-                        monitor_printf( mon, "Set taint packet successfully\n\n" );
-                     }
-                     else {
-                        if ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_NO ) != 0 ) {
-                            monitor_printf( mon, "set taint packet failed\n");
+                        if ( dba_enable_taint_packet( tid ) != 0 ) {
+                            monitor_printf( mon, "Enable taint packet failed\n" );
                             return 1;
                         }
-                        else {
-                            cb_dba_set_taint_packet( mon, json_object_get_string( jo_content ), opaque );
-                            monitor_printf( mon, "no taint packet\n\n" );
-                        }   
+                        monitor_printf( mon, "Set taint packet successfully\n" );
+                     }
+                     else {
+                        if ( dba_disable_taint_packet( tid ) != 0 ) {
+                            monitor_printf( mon, "Disable taint packet failed\n" );
+                            return 1;
+                        }
+                        monitor_printf( mon, "No taint packet\n" );
                      }
                 }
                 else {
@@ -547,14 +577,11 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
                 }
             }
             else {
-                if ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_NO ) != 0 ) {
-                    monitor_printf( mon, "set taint failed\n");
+                if ( dba_disable_taint_analysis( tid ) != 0 ) {
+                    monitor_printf( mon, "Disable Taint ablility failed\n" );
                     return 1;
                 }
-                else {
-                    cb_dba_set_taint( mon, "n", opaque );
-                    monitor_printf( mon, "No Taint ablility\n\n" );
-                }
+                monitor_printf( mon, "No Taint ablility\n" );
             }
         }
         else {
@@ -563,7 +590,7 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
         }
     }
     else {
-        monitor_printf( mon, "Cannot get taint tag\n");
+        monitor_printf( mon, "Cannot get taint json tag\n");
         return 1;
     }
     // Taint
@@ -572,18 +599,18 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
     if ( json_object_object_get_ex( (json_object*)jo_config, CONFIG_TAG_SYSCALL_TRACER, &jo_object ) ) {
         if ( json_object_object_get_ex( jo_object, CONFIG_TAG_ENABLE, &jo_content ) ) {
             if ( ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_content ), CONFIG_TAG_Y ) == 0 ) ) {
-                cb_dba_set_syscall( NULL, json_object_get_string( jo_content ), opaque );
-                monitor_printf( mon, "Set Syscall ability successfully\n\n");
-            }
-            else {
-                if ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_NO ) != 0 ) {
-                    monitor_printf( mon, "Syscall set fail\n");
+                if ( dba_enable_syscall_trace( tid ) != 0 ) {
+                    monitor_printf( mon, "Enable Syscall ability Failed\n");
                     return 1;
                 }
-                else {
-                    cb_dba_set_syscall( NULL, "n", opaque );
-                    monitor_printf( mon, "No Syscall ability\n\n");
+                monitor_printf( mon, "Set Syscall ability successfully\n");
+            }
+            else {
+                if ( dba_disable_syscall_trace( tid ) != 0 ) {
+                    monitor_printf( mon, "Disable Syscall ability Failed\n");
+                    return 1;
                 }
+                monitor_printf( mon, "No Syscall ability\n");
             }
         }
         else {
@@ -602,138 +629,145 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
 
         if ( json_object_object_get_ex( jo_object, CONFIG_TAG_ENABLE, &jo_content ) ) { 
             if ( ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_content ), CONFIG_TAG_Y ) == 0 ) ) {
+                
                 // Load structure
                 if ( json_object_object_get_ex( jo_object, CONFIG_TAG_STRUC, &jo_content ) ) {
-                    cb_dba_set_structure( NULL, json_object_get_string( jo_content ), opaque );
-                    monitor_printf( mon, "set tracer with given structure\n");
+                    if ( dba_set_structure( tid, json_object_get_string( jo_content ) ) != 0 ) {
+                        monitor_printf( mon, "Set with given structure json file failed\n");
+                        return 1;
+                    }
+                    monitor_printf( mon, "Set tracer with given structure json file successfully\n");
                 }
                 else {
-                    monitor_printf( mon, "set tracer without giving structure\n");
+                    monitor_printf( mon, "Set tracer without giving structure json file\n");
                     return 1;
                 }
 
                 // Load global variable
                 if ( json_object_object_get_ex( jo_object, CONFIG_TAG_GLOBV, &jo_content ) ) {
-                    cb_dba_set_global( NULL, json_object_get_string( jo_content ), opaque );
-                    monitor_printf( mon, "set tracer with given global variable\n");
+                    if ( dba_set_global( tid, json_object_get_string( jo_content ) ) != 0 ) {
+                        monitor_printf( mon, "Set with given global variable json file failed\n");
+                        return 1;
+                    }
+                    monitor_printf( mon, "Set tracer with given global variable json file successfully\n");
                 }
                 else {
-                    monitor_printf( mon, "set tracer without giving global variable\n");
+                    monitor_printf( mon, "set tracer without giving global variable json file\n");
                     return 1;
                 }
-            }
-
-            // instruction
-            if ( json_object_object_get_ex( jo_object, CONFIG_TAG_INSTR, &jo_content ) ) {
                 
-                json_object* jo_enable;
-                json_object* jo_is_kernel;
+                // instruction
+                if ( json_object_object_get_ex( jo_object, CONFIG_TAG_INSTR, &jo_content ) ) {
+                    
+                    json_object* jo_enable;
+                    json_object* jo_is_kernel;
 
-                // Make sure the "enable" and "is_kernel" tag in the json object
-                if ( json_object_object_get_ex( jo_content, CONFIG_TAG_ENABLE, &jo_enable ) && json_object_object_get_ex( jo_content, CONFIG_TAG_IS_KERNEL, &jo_is_kernel ) ) {
-                    // Deal with the enable tag
-                    if ( ( strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_Y ) == 0 ) ) {
-                        cb_dba_set_instr( NULL, json_object_get_string( jo_enable ), opaque );
-                        monitor_printf( mon, "set instruction tracer successfully\n");
-                        // Deal with the is_kernel tag
-                        if ( ( strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_Y ) == 0 ) ) {
-                            cb_dba_set_instr_is_kernel( NULL, json_object_get_string( jo_is_kernel ), opaque );
-                            monitor_printf( mon, "set in kernel level successfully\n\n");
-                        }
-                        else {
-                            if ( strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_NO ) != 0 ) {
-                                monitor_printf( mon, "set in kernel level failed\n");
+                    // Make sure the "enable" and "is_kernel" tag in the json object
+                    if ( json_object_object_get_ex( jo_content, CONFIG_TAG_ENABLE, &jo_enable ) && json_object_object_get_ex( jo_content, CONFIG_TAG_IS_KERNEL, &jo_is_kernel ) ) {
+                        // Deal with the enable tag
+                        if ( ( strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_Y ) == 0 ) ) {
+                            if ( dba_enable_instr_tracer( tid ) != 0 ) {
+                                monitor_printf( mon, "set instruction tracer failed\n");
                                 return 1;
                             }
-                            else {
-                                cb_dba_set_instr_is_kernel( NULL, json_object_get_string( jo_is_kernel ), opaque );
-                                monitor_printf( mon, "set in user level successfully\n\n");
+                            monitor_printf( mon, "set instruction tracer successfully\n");
+                            // Deal with the is_kernel tag
+                            if ( ( strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_Y ) == 0 ) ) {
+                                if ( dba_enable_instr_tracer_is_kernel( tid ) != 0 ) {
+                                    monitor_printf( mon, "set instruction tracer in kernel level failed\n");
+                                    return 1;
+                                }
+                                monitor_printf( mon, "set instruction tracer in kernel level successfully\n");
                             }
+                            else {
+                                if ( dba_disable_instr_tracer_is_kernel( tid ) != 0 ) {
+                                    monitor_printf( mon, "set instruction tracer in user level failed\n");
+                                    return 1;
+                                }
+                                monitor_printf( mon, "set instruction tracer in user level successfully\n");
+                            }
+                        }
+                        else {
+                            if ( dba_disable_instr_tracer( tid ) != 0 ) {
+                                monitor_printf( mon, "Disable instruction tracer ability failed\n");
+                                return 1;
+                            }
+                            monitor_printf( mon, "No instruction tracer ability\n");
                         }
                     }
                     else {
-                        if ( strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_NO ) != 0 ) {
-                            monitor_printf( mon, "set instruction tracer failed\n");
-                            return 1;
-                        }
-                        else {
-                            cb_dba_set_instr( NULL, json_object_get_string( jo_enable ), opaque );
-                            monitor_printf( mon, "no instruction tracer ablility\n\n");
-                        }
+                        monitor_printf( mon, "Instruction Tracer cannot get \"enable\" or \"is_kernel\" tag\n");
+                        return 1;
                     }
                 }
                 else {
-                    monitor_printf( mon, "Instruction Tracer cannot get \"enable\" or \"is_kernel\" tag\n");
+                    monitor_printf( mon, "Cannot get instruction tracer tag\n");
                     return 1;
                 }
-            }
-            else {
-                monitor_printf( mon, "Cannot get instruction tracer tag\n");
-                return 1;
-            }
-            // instruction
-            // block
-            if ( json_object_object_get_ex( jo_object, CONFIG_TAG_BLOCK, &jo_content ) ) {
-                
-                json_object* jo_enable;
-                json_object* jo_is_kernel;
-
-                // Make sure the "enable" and "is_kernel" tag in the json object
-                if ( json_object_object_get_ex( jo_content, CONFIG_TAG_ENABLE, &jo_enable ) && json_object_object_get_ex( jo_content, CONFIG_TAG_IS_KERNEL, &jo_is_kernel ) ) {
-                    // Deal with the enable tag
-                    if ( ( strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_Y ) == 0 ) ) {
-                        cb_dba_set_block( NULL, json_object_get_string( jo_enable ), opaque );
-                        monitor_printf( mon, "set block tracer successfully\n");
-                        // Deal with the is_kernel tag
-                        if ( ( strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_Y ) == 0 ) ) {
-                            cb_dba_set_block_is_kernel( NULL, json_object_get_string( jo_is_kernel ), opaque );
-                            monitor_printf( mon, "set in kernel level successfully\n\n");
-                        }
-                        else {
-                            if ( strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_NO ) != 0 ) {
-                                monitor_printf( mon, "set in kernel level failed\n");
+                // instruction
+                // block
+                if ( json_object_object_get_ex( jo_object, CONFIG_TAG_BLOCK, &jo_content ) ) {
+                    
+                    json_object* jo_enable;
+                    json_object* jo_is_kernel;
+                    
+                    // Make sure the "enable" and "is_kernel" tag in the json object
+                    if ( json_object_object_get_ex( jo_content, CONFIG_TAG_ENABLE, &jo_enable ) && json_object_object_get_ex( jo_content, CONFIG_TAG_IS_KERNEL, &jo_is_kernel ) ) {
+                        // Deal with the enable tag
+                        if ( ( strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_Y ) == 0 ) ) {
+                            if ( dba_enable_block_tracer( tid ) != 0 ) {
+                                monitor_printf( mon, "Enable block tracer ablility failed\n");
                                 return 1;
                             }
-                            else {
-                                cb_dba_set_block_is_kernel( NULL, json_object_get_string( jo_is_kernel ), opaque );
-                                monitor_printf( mon, "set in user level successfully\n\n");
+                            monitor_printf( mon, "Enable block tracer successfully\n");
+                            // Deal with the is_kernel tag
+                            if ( ( strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_YES ) == 0 || strcmp( json_object_get_string( jo_is_kernel ), CONFIG_TAG_Y ) == 0 ) ) {
+                                if ( dba_enable_block_tracer_is_kernel( tid ) != 0 ) {
+                                    monitor_printf( mon, "Set block tracer in kernel level failed\n");
+                                    return 1;
+                                }
+                                monitor_printf( mon, "Set block tracer in kernel level successfully\n\n");
                             }
+                            else {
+                                if ( dba_disable_block_tracer_is_kernel( tid ) != 0 ) {
+                                    monitor_printf( mon, "Set block tracer in user level failed\n");
+                                    return 1;
+                                }
+                                monitor_printf( mon, "Set block tracer in user level successfully\n");
+                            }
+                        }
+                        else {
+                            if ( dba_disable_block_tracer( tid ) != 0 ) {
+                                monitor_printf( mon, "Disable block tracer ability failed\n");
+                                return 1;
+                            }
+                            monitor_printf( mon, "No block tracer ability\n");
                         }
                     }
                     else {
-                        if ( strcmp( json_object_get_string( jo_enable ), CONFIG_TAG_NO ) != 0 ) {
-                         monitor_printf( mon, "set block tracer failed\n");
-                         return 1;
-                        }
-                        else {
-                            cb_dba_set_block( NULL, json_object_get_string( jo_enable ), opaque );
-                            monitor_printf( mon, "no block tracer ablilty\n\n");
-                        }
+                        monitor_printf( mon, "Block Tracer cannot get \"enable\" or \"is_kernel\" tag\n");
+                        return 1;
                     }
                 }
                 else {
-                    monitor_printf( mon, "Block Tracer cannot get \"enable\" or \"is_kernel\" tag\n");
+                    monitor_printf( mon, "Cannot get block tracer tag\n");
                     return 1;
                 }
+                // block
             }
             else {
-                monitor_printf( mon, "Cannot get block tracer tag\n");
-                return 1;
+                // Disable all the Tracer ability
+                if ( dba_disable_instr_tracer( tid ) != 0 || dba_disable_instr_tracer_is_kernel( tid ) != 0 ||
+                     dba_disable_block_tracer( tid ) != 0 || dba_disable_block_tracer_is_kernel( tid ) != 0   ){
+                     monitor_printf( mon, "Set without tracer ability failed\n");
+                     return 1;
+                }
+                monitor_printf( mon, "Set without tracer ability\n");
             }
-            // block
         }
         else {
-            if ( strcmp( json_object_get_string( jo_content ), CONFIG_TAG_NO ) != 0 ) {
-                monitor_printf( mon, "set tracer failed\n");
-                return 1;
-            }
-            else {
-                cb_dba_set_instr( NULL, "no", opaque );
-                cb_dba_set_instr_is_kernel( NULL, "no", opaque );
-                cb_dba_set_block( NULL, "no", opaque );
-                cb_dba_set_block_is_kernel( NULL, "no", opaque );
-                monitor_printf( mon, "set without tracer ability\n");
-            }
+            monitor_printf( mon, "Cannot get tracer enable tag\n");
+            return 1;
         }
     }
     else {
@@ -741,6 +775,11 @@ static int dba_set_by_config ( Monitor* mon, const char* config_file_path, void*
         return 1;
     }
     // Instrution Tracer
+
+    monitor_printf( mon, "=====================================\n" );
+    monitor_printf( mon, "====== Finishing Setting Up DBA =====\n" );
+    monitor_printf( mon, "=====================================\n\n" );
+    // DBA Abilities
 
     return 0;
 }
@@ -815,27 +854,40 @@ void do_start_dba_task( Monitor* mon, const QDict* qdict ) {
     // Set monitor pointer to the task in order to print out the finish message
     if ( dba_set_monitor( tid, mon ) != 0 ) {
         monitor_printf( mon, "Set monitor pointer fail\n");
+        switch( dba_errno ) {
+            case DBA_ERR_INVALID_TID:
+                monitor_printf( mon, "Invalid task ID\n" );
+                break;
+            case DBA_ERR_INVALID_TSTATE:
+                monitor_printf( mon, "Task unconfigurable\n" );
+                break;
+            default:
+                monitor_printf( mon, "General failure\n" );
+                break;
+        }
+        dba_delete_task( tid );
         return;
     }
 
     // Set by the config file
     if ( config_file_path != NULL ) {
 
-        use_config_file = TRUE;
-        monitor_printf( mon, "Set with config file\n" );
-        if ( dba_set_by_config( mon, config_file_path, (void*)tid ) != 0 ) {
+        monitor_printf( mon, "* * * * * * * * * * * * * *\n" );
+        monitor_printf( mon, "* Set up with config file *\n" );
+        monitor_printf( mon, "* * * * * * * * * * * * * *\n" );
+
+        if ( dba_set_by_config( mon, config_file_path, tid ) != 0 ) {
             monitor_printf( mon, "Set task by config file fail\n");
-            use_config_file = FALSE;
         }
         else {
-            use_config_file = FALSE;
             cb_dba_confirm( mon, "yes", (void*)tid );
         }
     }
     else {
 
-        use_config_file = FALSE;
-        monitor_printf( mon, "Set without config file\n" );
+        monitor_printf( mon, "* * * * * * * * * * * * *\n" );
+        monitor_printf( mon, "* Set up with interface *\n" );
+        monitor_printf( mon, "* * * * * * * * * * * * *\n" );
 
         // callback chain as questions to setup DBA context
         //  1. ask user for taint option
@@ -1008,12 +1060,4 @@ void do_show_dba_result( Monitor* mon, const QDict* qdict ) {
         fclose( fp );
         monitor_printf( mon, "Finished writing result to targeted file\n" );
     }
-}
-
-// Used to check which setting mode is now
-// Return TRUE for setting by config file, FALSE for command line setting
-bool do_dba_config_file_setting ( void ) {
-
-    return use_config_file ;
-
 }

--- a/ext/dba/dba-commands.h
+++ b/ext/dba/dba-commands.h
@@ -27,5 +27,4 @@ void do_start_dba_task( Monitor* mon, const QDict* qdict );
 void do_list_dba_task( Monitor* mon, const QDict* qdict );
 void do_delete_dba_task( Monitor* mon, const QDict* qdict );
 void do_show_dba_result( Monitor* mon, const QDict* qdict );
-bool do_dba_config_file_setting ( void );
 #endif

--- a/ext/dba/dba.h
+++ b/ext/dba/dba.h
@@ -68,12 +68,12 @@ typedef enum DBA_TASK_STATE DBA_TASK_STATE;
 struct dba_context {
 
     int          task_id;
-    // CR3 od sample, and should not be directly used without hooking on MmCreatePeb
+    // CR3 of sample should not be directly used without hooking on MmCreatePeb
     target_ulong task_cr3;
 
-    // Record of taint ability setting
+    // Record of Taint ability setting
     struct {
-        // Swithch of TAINT ability and taint tag
+        // Switch of Taint ability and taint tag
         bool                    is_enabled;
         CONTAMINATION_RECORD    tag;
         // Switch of Taint packet and the callback function id of NTM
@@ -86,13 +86,13 @@ struct dba_context {
     } syscall;
 
     struct {
-        // Switch of TRACER ability in instructions 
+        // Switch of Tracer ability in instructions 
         bool instr_enabled;
         // Flag for choosing in what level while tracing
         bool instr_is_kernel;
         // Callback function ID of instruction tracer
         int  instr_tracer_cb_id;
-        // Switch of TRACER ability in block instructions 
+        // Switch of Tracer ability in block instructions 
         bool block_enabled;
         // Flag for choosing in what level while tracing
         bool block_is_kernel;
@@ -106,7 +106,7 @@ struct dba_context {
     char   sample_gpath[ DBA_MAX_FILENAME + sizeof(DBA_GUEST_SAMPLE_DIR) ];
     size_t sample_timer;
 
-    // Sample name that will used to identify whather the created process is the sample we put into
+    // Sample name that will be used to identify whether the created process is the sample we put
     char   sample_name[ DBA_MAX_FILENAME + 1 ];
 
     json_object* result;

--- a/ext/dba/dba.h
+++ b/ext/dba/dba.h
@@ -28,6 +28,7 @@
 #include "ext/dift/dift.h"
 #include "ext/agent/agent.h"
 #include "ext/nettramon/nettramon.h"
+#include "ext/tracer/tracer.h"
 #include "monitor/monitor.h"
 
 #define DBA_MAX_TASKS               0x1000
@@ -37,6 +38,7 @@
 
 #define DBA_JSON_KEY_TAINT          "TAINT"
 #define DBA_JSON_KEY_SYSCALL        "SYSCALL"
+#define DBA_JSON_KEY_TRACER         "TRACER"
 
 // DBA Task ID
 typedef intptr_t DBA_TID;
@@ -78,10 +80,12 @@ struct dba_context {
     } syscall;
 
     struct {
-        bool is_enabled;
         bool instr_enabled;
+        bool instr_is_kernel;
+        int  instr_tracer_cb_id;
         bool block_enabled;
-        int  intr_tracer_cb_id;
+        bool block_is_kernel;
+        int  block_tracer_cb_id;
         int  mmcreatepeb_hook_id;
     } instr_tracer;
 
@@ -156,6 +160,70 @@ extern int dba_set_timer( DBA_TID tid, size_t seconds );
 ///
 /// Return 0 on success, otherwise -1 is returned and the dba_errno is set
 extern int dba_set_sample( DBA_TID tid, const char* path );
+
+/// Enable block tracer in kernel address for the DBA task speicified by ID
+/// Note that the task must be IDLE to be configurable
+///
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_enable_block_tracer_is_kernel( DBA_TID tid );
+
+/// Disable block tracer in kernel address for the DBA task speicified by ID
+///
+/// Note that the task must be IDLE to be configurable
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_disable_block_tracer_is_kernel( DBA_TID tid );
+
+/// Enable block tracer for the DBA task speicified by ID
+/// Note that the task must be IDLE to be configurable
+///
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_enable_block_tracer( DBA_TID tid );
+
+/// Disable block tracer for the DBA task speicified by ID
+///
+/// Note that the task must be IDLE to be configurable
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_disable_block_tracer( DBA_TID tid );
+
+/// Enable instruction tracer in kernel address for the DBA task speicified by ID
+/// Note that the task must be IDLE to be configurable
+///
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_enable_instr_tracer_is_kernel( DBA_TID tid );
+
+/// Disable instruction tracer in kernel address for the DBA task speicified by ID
+///
+/// Note that the task must be IDLE to be configurable
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_disable_instr_tracer_is_kernel( DBA_TID tid );
+
+/// Enable instruction tracer for the DBA task speicified by ID
+/// Note that the task must be IDLE to be configurable
+///
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_enable_instr_tracer( DBA_TID tid );
+
+/// Disable instruction tracer for the DBA task speicified by ID
+///
+/// Note that the task must be IDLE to be configurable
+///     \param  tid     DBA task ID
+///
+/// Return 0 on success, otherwise -1 is returned and the dba_errno is set
+extern int dba_disable_instr_tracer( DBA_TID tid );
 
 /// Enable system call tracer for the DBA task speicified by ID
 /// Note that the task must be IDLE to be configurable

--- a/ext/dba/dba.h
+++ b/ext/dba/dba.h
@@ -2,6 +2,7 @@
  *  MBA Dynamic Behavior Analyzer, DBA header
  *
  *  Copyright (c)   2016 Chiawei Wang
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,7 +33,7 @@
 #define DBA_MAX_TASKS               0x1000
 #define DBA_MAX_FILENAME            255
 #define DBA_GUEST_SAMPLE_DIR        "/Users/dsns/Desktop/"
-#define DBA_MAX_TAINT_PACKET_LENGTH 1024 
+#define DBA_MAX_TAINT_PACKET_LENGTH 1024
 
 #define DBA_JSON_KEY_TAINT          "TAINT"
 #define DBA_JSON_KEY_SYSCALL        "SYSCALL"
@@ -62,20 +63,33 @@ typedef enum DBA_TASK_STATE DBA_TASK_STATE;
 
 struct dba_context {
 
-    int task_id;
+    int          task_id;
+    target_ulong task_cr3;
 
     struct {
-        bool is_enabled;
-        CONTAMINATION_RECORD tag;
+        bool                    is_enabled;
+        CONTAMINATION_RECORD    tag;
+        bool                    ntm_is_enabled;
+        int                     ntm_cb_id;
     } taint;
 
     struct {
         bool is_enabled;
     } syscall;
 
+    struct {
+        bool is_enabled;
+        bool instr_enabled;
+        bool block_enabled;
+        int  intr_tracer_cb_id;
+        int  mmcreatepeb_hook_id;
+    } instr_tracer;
+
     char   sample_hpath[ DBA_MAX_FILENAME + 1 ];
     char   sample_gpath[ DBA_MAX_FILENAME + sizeof(DBA_GUEST_SAMPLE_DIR) ];
     size_t sample_timer;
+
+    char   sample_name[ DBA_MAX_FILENAME + 1 ];
 
     json_object* result;
 

--- a/ext/dba/dba_config_sample
+++ b/ext/dba/dba_config_sample
@@ -1,1 +1,30 @@
-{"MODULE":{"AGENT":"no","DIFT":"no","NETTRAMON":"no"},"TAINT":{"ENABLE":"no","TAG":"1"},"SYSCALL_TRACER":{"ENABLE":"no"}}
+{
+    "MODULE":
+    {
+        "AGENT":"no",
+        "DIFT":"no",
+        "NETTRAMON":"no"
+    },
+    "TAINT":
+    {
+        "ENABLE":"no",
+        "TAG":"1"
+    },
+    "SYSCALL_TRACER":
+    {
+        "ENABLE":"no"
+    },
+    "INSTR_TRACER":
+    {
+        "INSTR":
+        {
+            "ENABLE":"yes",
+            "IS_KERNEL":"no"
+        },
+        "BLOCK":
+        {
+            "ENABLE":"no",
+            "IS_KERNEL":"no"
+        }
+    }
+}

--- a/ext/dba/dba_config_sample
+++ b/ext/dba/dba_config_sample
@@ -3,12 +3,20 @@
     {
         "AGENT":"no",
         "DIFT":"no",
-        "NETTRAMON":"no"
+        "NETTRAMON":
+        {
+            "ENABLE":"no",
+            "ALL":"RELATIVE_OR_ABSOLUTE_PATH_TO_THE_FILE",
+            "TCP":"RELATIVE_OR_ABSOLUTE_PATH_TO_THE_FILE",
+            "UDP":"RELATIVE_OR_ABSOLUTE_PATH_TO_THE_FILE",
+            "ICMP":"RELATIVE_OR_ABSOLUTE_PATH_TO_THE_FILE"
+        }
     },
     "TAINT":
     {
         "ENABLE":"no",
-        "TAG":"1"
+        "PACKET":"no",
+        "TAG":"0_TO_255"
     },
     "SYSCALL_TRACER":
     {
@@ -16,9 +24,12 @@
     },
     "INSTR_TRACER":
     {
+        "ENABLE":"no",
+        "STRUCTURE":"RELATIVE_OR_ABSOLUTE_PATH_TO_THE_FILE",
+        "GLOBALVAR":"RELATIVE_OR_ABSOLUTE_PATH_TO_THE_FILE",
         "INSTR":
         {
-            "ENABLE":"yes",
+            "ENABLE":"no",
             "IS_KERNEL":"no"
         },
         "BLOCK":

--- a/ext/dba/dba_taint.c
+++ b/ext/dba/dba_taint.c
@@ -1,3 +1,24 @@
+/*
+ *
+ *  Taint ability of DBA
+ *
+ *  Copyright (c)    2017 JuiChien Jao
+ *                   2016 ChiaWei Wang
+ *
+ * This library is free software you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "dba_taint.h"
 
 #include "qemu/thread.h"

--- a/ext/dba/dba_taint.h
+++ b/ext/dba/dba_taint.h
@@ -1,3 +1,23 @@
+/*
+ *
+ *  Taint ability of DBA
+ *
+ *  Copyright (c)    2017 JuiChien Jao
+ *                   2016 ChiaWei Wang
+ *
+ * This library is free software you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef __DBA_TAINT_H__
 #define __DBA_TAINT_H__
 

--- a/ext/dba/dba_tracer.c
+++ b/ext/dba/dba_tracer.c
@@ -1,0 +1,232 @@
+/*
+ *
+ *  Tracer abilities of DBA
+ *
+ *  Copyright (c)    2017 JuiChien Jao
+ *
+ * This library is free software you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#include "dba_tracer.h"
+#include "ext/obhook/obhook.h"
+#include "disas/disas.h"
+
+#define RFT_INSTR                   "Instruction"
+#define RFT_BLOCK                   "Block"
+#define MAX_SZ_TRACER_LABEL         16
+
+static void* cb_instr_tracer( void* env_state, uint64_t start_addr, uint64_t useless_arg, void* cur_ctx ) {
+
+    X86CPU* cpu = X86_CPU(env_state);
+    CPUX86State *env = &cpu->env;
+    dba_context* ctx = (dba_context*)cur_ctx;
+    char*   instr_buf;
+    size_t buf_size;
+    FILE* instr_fp = open_memstream( &instr_buf, &buf_size );
+
+    json_object*    jo_tracer;
+    json_object*    jo_instr;
+   
+    target_disas_inst_count( instr_fp, env, start_addr, 100, 1, 2);
+    fprintf( instr_fp, "\teax %08lx\t", env->regs[R_EAX]);
+    fprintf( instr_fp, "ebx %08lx\t", env->regs[R_EBX]);
+    fprintf( instr_fp, "ecx %08lx\t", env->regs[R_ECX]);
+    fprintf( instr_fp, "edx %08lx\n", env->regs[R_EDX]);
+    fprintf( instr_fp, "\tcr3 %08lx\n", env->cr[3]);
+    fprintf( instr_fp, "\n");
+    fclose( instr_fp );
+
+    // get JSON object for tracer
+    json_object_object_get_ex( ((dba_context*)ctx)->result, DBA_JSON_KEY_TRACER, &jo_tracer); 
+   
+    // check if the JSON object is already in the tracer result
+    if ( !json_object_object_get_ex( jo_tracer, RFT_INSTR, &jo_instr ) ) {
+        // add array JSON object to store tainted packet
+        jo_instr = json_object_new_array();
+        json_object_object_add( jo_tracer, RFT_INSTR, jo_instr );
+    }
+    
+    json_object_array_add( jo_instr, json_object_new_string( instr_buf ) );
+    
+    free( instr_buf );
+
+    return NULL;
+}
+
+static void* cb_block_tracer( void* env_state, uint64_t start_addr, uint64_t end_addr, void* cur_ctx ) {
+    
+    X86CPU* cpu = X86_CPU(env_state);
+    CPUX86State *env = &cpu->env;
+    dba_context* ctx = (dba_context*)cur_ctx;
+
+    char*   instr_buf;
+    size_t buf_size;
+    FILE* instr_fp = open_memstream( &instr_buf, &buf_size );
+    uint64_t tmp_addr = start_addr;
+
+    json_object*    jo_tracer;
+    json_object*    jo_block;
+    
+    while ( tmp_addr <= end_addr ) {
+        tmp_addr += target_disas_inst_count( instr_fp, env, tmp_addr, 100, 1, 2);
+        fprintf( instr_fp, "\teax %08lx\t", env->regs[R_EAX]);
+        fprintf( instr_fp, "ebx %08lx\t", env->regs[R_EBX]);
+        fprintf( instr_fp, "ecx %08lx\t", env->regs[R_ECX]);
+        fprintf( instr_fp, "edx %08lx\n", env->regs[R_EDX]);
+        fprintf( instr_fp, "\tcr3 %08lx\n", env->cr[3]);
+        fprintf( instr_fp, "\n");
+    }
+    fclose(instr_fp);
+
+    // get JSON object for tracer
+    json_object_object_get_ex( ((dba_context*)ctx)->result, DBA_JSON_KEY_TRACER, &jo_tracer);
+   
+    // check if the JSON object is already in the tracer result
+    if ( !json_object_object_get_ex( jo_tracer, RFT_BLOCK, &jo_block ) ) {
+        // add array JSON object to store tainted packet
+        jo_block = json_object_new_array();
+        json_object_object_add( jo_tracer, RFT_BLOCK, jo_block );
+    }
+    
+    json_object_array_add( jo_block, json_object_new_string( instr_buf ) );
+    
+    free( instr_buf );
+    
+    return NULL;
+}
+
+static void* cb_hook_mmcreatepeb( void* cpu, void* cur_ctx ) {
+
+    X86CPU *x86cpu = ( X86CPU* )cpu;
+    dba_context* ctx = (dba_context*)cur_ctx;
+    target_ulong eprocess_addr;
+    char img_name[DBA_MAX_SZ_IMG_NAME];
+    target_ulong cr3;
+
+    // check if process name correct
+    eprocess_addr = x86cpu->env.regs[R_ECX];
+
+    // get program name (16 bytes)
+    if( memfrs_get_mem_struct_content(
+            (CPUState*)x86cpu, 0, (uint8_t*)img_name, DBA_MAX_SZ_IMG_NAME,
+            eprocess_addr, false, "_EPROCESS", 1, "#ImageFileName") == -1 ) {
+        return NULL;
+    }
+
+    // check whether the program name is the same as the task record
+    if ( strncmp( ctx->sample_name, img_name, DBA_MAX_SZ_IMG_NAME ) != 0 ) {
+        return NULL;
+    }
+
+    // get directory table base (CR3)
+    if ( memfrs_get_mem_struct_content( (CPUState*)x86cpu, 0, (uint8_t*)&cr3, sizeof(cr3), eprocess_addr,
+                                        false, "_EPROCESS", 2, "#Pcb", "#DirectoryTableBase") == -1 ) {
+        monitor_printf( ctx->mon, "Fail to get CR3 of Task %d\n", ctx->task_id );
+        return NULL;
+    }
+
+    // get current task's cr3
+    ctx->task_cr3 = cr3;
+    
+    // TODO: Add Tracer Callback function
+    if ( ctx->instr_tracer.instr_enabled ) {
+        ctx->instr_tracer.instr_tracer_cb_id = tracer_add_inst_tracer( ctx->task_cr3, "DBA_TASK", ctx->instr_tracer.instr_is_kernel, cb_instr_tracer, cur_ctx );
+        if ( ctx->instr_tracer.instr_tracer_cb_id == -1 ) {
+            monitor_printf( ctx->mon, "Fail to register instr tracer of Task %d\n", ctx->task_id );
+            return NULL;
+        }
+        if ( tracer_enable_tracer( ctx->instr_tracer.instr_tracer_cb_id ) == -1 ) {
+            monitor_printf( ctx->mon, "Fail to enable instr tracer of Task %d\n", ctx->task_id );
+            return NULL;
+        }
+    }
+
+    if ( ctx->instr_tracer.block_enabled ) {
+        ctx->instr_tracer.block_tracer_cb_id = tracer_add_block_tracer( ctx->task_cr3, "DBA_TASK", ctx->instr_tracer.block_is_kernel, cb_block_tracer, cur_ctx );
+        if ( ctx->instr_tracer.block_tracer_cb_id == -1 ) {
+            monitor_printf( ctx->mon, "Fail to register block tracer of Task %d\n", ctx->task_id );
+            return NULL;
+        }
+        if ( tracer_enable_tracer( ctx->instr_tracer.block_tracer_cb_id ) ) {
+            monitor_printf( ctx->mon, "Fail to enable block tracer of Task %d\n", ctx->task_id );
+            return NULL;
+        }
+    }
+
+    return NULL;
+
+}
+
+// get kernel base, find it if it's not found yet
+target_ulong get_kernel_address_base( void ) {
+    target_ulong kernel_base_address;
+    CPUState *cpu;
+
+    kernel_base_address = memfrs_get_nt_kernel_base();
+    if( kernel_base_address != 0 )
+        return kernel_base_address;
+
+    cpu = first_cpu;
+    if( cpu == NULL ) {
+        return 0;
+    }
+
+    return memfrs_find_nt_kernel_base( cpu );
+}
+
+// get kernel variable in-guest virtual address
+int get_gvar_addr( const char *var_name, target_ulong *out ) {
+    json_object *gvar;
+    target_ulong kernel_base_address;
+
+    kernel_base_address = get_kernel_address_base();
+    if( kernel_base_address == 0 )
+        return -1;
+
+    gvar = memfrs_q_globalvar( var_name );
+    if( gvar == NULL )
+        return -1;
+
+    *out = memfrs_gvar_offset( gvar ) + kernel_base_address;
+    return 0;
+}
+
+// Setup 
+int set_obhook_on_mmcreatepeb( dba_context* ctx ) {
+
+    target_ulong mmcreatepeb;
+    json_object *jo_out;
+    int ret_val;
+
+    // get JSON object for syscall result
+    json_object_object_get_ex( ctx->result, DBA_JSON_KEY_SYSCALL, &jo_out );
+    
+    // get MmCreatePeb function address
+    ret_val = get_gvar_addr( "MmCreatePeb", &mmcreatepeb );
+    if( ret_val == -1 ) {
+        monitor_printf( ctx->mon, "Task %d failed to get MmCreatePeb function address\n", ctx->task_id );
+        return 1;
+    }
+    
+    // register MmCreatePeb obhook, for process creation hooking
+    ret_val = obhook_add_universal( mmcreatepeb, DBA_HOOK_PROC_CREATE_TAG, cb_hook_mmcreatepeb, (void*)ctx );
+    if( ret_val == -1 ) {
+        monitor_printf( ctx->mon, "Task %d failed to hook process creation\n", ctx->task_id );
+        return 1;
+    }
+
+    ctx->instr_tracer.mmcreatepeb_hook_id = ret_val;
+
+    return 0;
+}
+

--- a/ext/dba/dba_tracer.h
+++ b/ext/dba/dba_tracer.h
@@ -1,5 +1,4 @@
 /*
- *
  *  Tracer abilities of DBA
  *
  *  Copyright (c)    2017 JuiChien Jao
@@ -22,12 +21,12 @@
 
 #include "dba.h"
 
-#define DBA_HOOK_PROC_CREATE_TAG    "dba"
-#define DBA_INSTRUCTION_TRACER_TAG  "dba"
-#define DBA_BLOCK_TRACER_TAG        "dba_block_tracer"
-#define DBA_MAX_SZ_IMG_NAME         14
+#define DBA_CALL_BACK_TAG    "DBA_TASK"
+#define DBA_MAX_SZ_IMG_NAME  14         // The 15th character is '\0'
 
 /// Get Kernel Base Address In-guest
+///
+///     \param None
 /// 
 /// Return a non-zero value for success, 0 for fail 
 extern target_ulong get_kernel_address_base( void );

--- a/ext/dba/dba_tracer.h
+++ b/ext/dba/dba_tracer.h
@@ -24,26 +24,26 @@
 #define DBA_CALL_BACK_TAG    "DBA_TASK"
 #define DBA_MAX_SZ_IMG_NAME  14         // The 15th character is '\0'
 
-/// Get Kernel Base Address In-guest
+/// Get Kernel Base Address of guest
 ///
 ///     \param None
 /// 
 /// Return a non-zero value for success, 0 for fail 
 extern target_ulong get_kernel_address_base( void );
 
-/// Get Kernel Variable In-guest Virtual Address
+/// Get Kernel Variable of guest 
 /// 
 ///     \param  var_name        variable name
 ///     \param  out             address of kernel variable 
 ///
-/// Return 0 if success, and other values for fail 
+/// Return 0 for success, -1 for fail
 extern int get_gvar_addr( const char *var_name, target_ulong *out);
 
-/// Setup dba_context for task
+/// Set up hook on MmCreatePeb to get the information of sample
 /// 
 ///     \param  ctx             pointer to dba_context of task
 ///
-/// Return 0 if success, and 1 for fail
+/// Return 0 for success, -1 for fail
 extern int set_obhook_on_mmcreatepeb( dba_context* ctx );
 
 #endif

--- a/ext/dba/dba_tracer.h
+++ b/ext/dba/dba_tracer.h
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Tracer abilities of DBA
+ *
+ *  Copyright (c)    2017 JuiChien Jao
+ *
+ * This library is free software you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef __DBA_TRACER_H__
+#define __DBA_TRACER_H__
+
+#include "dba.h"
+
+#define DBA_HOOK_PROC_CREATE_TAG    "dba"
+#define DBA_INSTRUCTION_TRACER_TAG  "dba"
+#define DBA_BLOCK_TRACER_TAG        "dba_block_tracer"
+#define DBA_MAX_SZ_IMG_NAME         14
+
+/// Get Kernel Base Address In-guest
+/// 
+/// Return a non-zero value for success, 0 for fail 
+extern target_ulong get_kernel_address_base( void );
+
+/// Get Kernel Variable In-guest Virtual Address
+/// 
+///     \param  var_name        variable name
+///     \param  out             address of kernel variable 
+///
+/// Return 0 if success, and other values for fail 
+extern int get_gvar_addr( const char *var_name, target_ulong *out);
+
+/// Setup dba_context for task
+/// 
+///     \param  ctx             pointer to dba_context of task
+///
+/// Return 0 if success, and 1 for fail
+extern int set_obhook_on_mmcreatepeb( dba_context* ctx );
+
+#endif

--- a/ext/obhook/obhook-commands.c
+++ b/ext/obhook/obhook-commands.c
@@ -22,6 +22,9 @@
 #include "obhook-commands.h"
 #include "obhook.h"
 
+#include "sysemu/sysemu.h"
+#include "qapi-types.h"
+
 void do_list_obhook( Monitor* mon, const QDict* qdict ) {
 
     obhk_ht_record* ht_rec;

--- a/ext/obhook/obhook.c
+++ b/ext/obhook/obhook.c
@@ -2,6 +2,7 @@
  *  Out-of-Box Hook implementation
  *
  *  Copyright (c)   2016 Chiawei Wang
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/ext/obhook/obhook.c
+++ b/ext/obhook/obhook.c
@@ -71,7 +71,7 @@ static int toggle_obhk( int obhook_d, bool enabled ) {
 
 /// Internal implementation of out-of-box hook registration
 /// Return 0 on success, -1 and errno is set otherwise.
-static int add_obhk_internal( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void*) ) {
+static int add_obhk_internal( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void*, void*), void* usr_cb_arg ) {
 
     obhk_ht_record* ht_rec;
     obhk_ht_record* ht_proc_rec;
@@ -155,6 +155,7 @@ static int add_obhk_internal( target_ulong cr3, target_ulong addr, const char* l
     cb_rec->enabled   = true;
     cb_rec->universal = (cb_rec->ht_rec->cr3 == 0)? true : false;
     cb_rec->cb_func   = cb;
+    cb_rec->cb_arg   = usr_cb_arg;
     strncpy( cb_rec->label, label, MAX_SZ_OBHOOK_LABEL );
 
     // add the callback record to the linked list & index table
@@ -200,7 +201,7 @@ get_obhk_cb_not_found:
 
 /// Public API of Out-of-Box hook
 /// Each API function should be named with the prefix 'obhook_'
-int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void*) ) {
+int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void*, void*), void* usr_cb_argu ) {
 
     int ret;
 
@@ -210,18 +211,18 @@ int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, 
     }
 
     pthread_rwlock_wrlock( &obhk_ctx->rwlock );
-    ret = add_obhk_internal( cr3, addr, label, cb );
+    ret = add_obhk_internal( cr3, addr, label, cb, usr_cb_argu );
     pthread_rwlock_unlock( &obhk_ctx->rwlock );
 
     return ret;
 }
 
-int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void*) ) {
+int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void*, void*), void* usr_cb_argu ) {
 
     int ret;
 
     pthread_rwlock_wrlock( &obhk_ctx->rwlock );
-    ret = add_obhk_internal( 0, kern_addr, label, cb );
+    ret = add_obhk_internal( 0, kern_addr, label, cb, usr_cb_argu );
     pthread_rwlock_unlock( &obhk_ctx->rwlock );
 
     return ret;

--- a/ext/obhook/obhook.c
+++ b/ext/obhook/obhook.c
@@ -155,7 +155,7 @@ static int add_obhk_internal( target_ulong cr3, target_ulong addr, const char* l
     cb_rec->enabled   = true;
     cb_rec->universal = (cb_rec->ht_rec->cr3 == 0)? true : false;
     cb_rec->cb_func   = cb;
-    cb_rec->cb_arg   = usr_cb_arg;
+    cb_rec->cb_arg    = usr_cb_arg;
     strncpy( cb_rec->label, label, MAX_SZ_OBHOOK_LABEL );
 
     // add the callback record to the linked list & index table

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -2,6 +2,7 @@
  *  Out-of-Box Hook header
  *
  *  Copyright (c)   2016 Chiawei Wang
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -78,6 +79,7 @@ struct obhk_cb_record {
     // user-friendly label string
     char label[MAX_SZ_OBHOOK_LABEL];
 
+    // cb_arg is the user-defined argument and it will be passed as the second parameter of callbaclk function.
     void* (*cb_func) (void*, void*);
     void* cb_arg;
 
@@ -125,8 +127,7 @@ extern bool obhook_pending_hooks;
 ///     \param  cb          callback routine to be invoked when the hook is triggered
 ///                         Note that each callback routine will be invoked and given
 ///                         a pointer to the current CPU state structure (CPUState*)
-///     \param  usr_cb_argu The argument of cb that will be transmitted as 
-///                         the "second" argument when calling callback function
+///     \param  usr_cb_argu User-defined argument that will be transmitted as the "second" parameter of callback function
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void *, void *), void* usr_cb_arg );
@@ -142,8 +143,7 @@ extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* 
 ///     \param  cb          callback routine to be invoked when the hook is triggered
 ///                         Note that each callback routine will be invoked and given
 ///                         a pointer to the current CPU state structure (CPUState*)
-///     \param  usr_cb_argu The argument of cb that will be transmitted as 
-///                         the "second" argument when calling callback function
+///     \param  usr_cb_argu User-defined argument that will be transmitted as the "second" parameter of callback function
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
 extern int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void *, void *), void* usr_cb_arg );

--- a/ext/obhook/obhook.h
+++ b/ext/obhook/obhook.h
@@ -78,7 +78,8 @@ struct obhk_cb_record {
     // user-friendly label string
     char label[MAX_SZ_OBHOOK_LABEL];
 
-    void* (*cb_func) (void*);
+    void* (*cb_func) (void*, void*);
+    void* cb_arg;
 
     struct obhk_cb_record* next;
 };
@@ -118,15 +119,17 @@ extern bool obhook_pending_hooks;
 
 /// Add a process-aware, out-of-box hook at the given address
 ///
-///     \param  cr3     CR3 value of the targeted process, should not be zero
-///     \param  addr    address to implant the hook
-///     \param  label   user-friendly name for the hook (optional, can be NULL)
-///     \param  cb      callback routine to be invoked when the hook is triggered
-///                     Note that each callback routine will be invoked and given
-///                     a pointer to the current CPU state structure (CPUState*)
+///     \param  cr3         CR3 value of the targeted process, should not be zero
+///     \param  addr        address to implant the hook
+///     \param  label       user-friendly name for the hook (optional, can be NULL)
+///     \param  cb          callback routine to be invoked when the hook is triggered
+///                         Note that each callback routine will be invoked and given
+///                         a pointer to the current CPU state structure (CPUState*)
+///     \param  usr_cb_argu The argument of cb that will be transmitted as 
+///                         the "second" argument when calling callback function
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
-extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void *) );
+extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* label, void*(*cb) (void *, void *), void* usr_cb_arg );
 
 /// Add an universal, out-of-box hook at the given kernel-space address
 ///
@@ -139,9 +142,11 @@ extern int obhook_add_process( target_ulong cr3, target_ulong addr, const char* 
 ///     \param  cb          callback routine to be invoked when the hook is triggered
 ///                         Note that each callback routine will be invoked and given
 ///                         a pointer to the current CPU state structure (CPUState*)
+///     \param  usr_cb_argu The argument of cb that will be transmitted as 
+///                         the "second" argument when calling callback function
 ///
 /// Return a new obhook descriptor on success, otherwise -1 is returned and the obhook_errno is set
-extern int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void *) );
+extern int obhook_add_universal( target_ulong kern_addr, const char* label, void*(*cb) (void *, void *), void* usr_cb_arg );
 
 /// Delete a out-of-box hook by the given descriptor
 ///

--- a/ext/obhook/test/obhook_unittest.cc
+++ b/ext/obhook/test/obhook_unittest.cc
@@ -56,7 +56,7 @@ extern "C" {
 #undef get_obhook_descriptor
 
 // dummy callback for the obhook registration test
-void* dummy_cb( void* arg ) {
+void* dummy_cb( void* arg, void* usr_arg ) {
     return NULL;
 }
 
@@ -93,92 +93,92 @@ TEST( KernelAddrCheckTest, InvalidKernelAddress ) {
 TEST( AddUnivHookTest, FullHookErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Return(-1) );
-    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_FULL_HOOK, obhook_errno );
 }
 TEST( AddUnivHookTest, InvalidAddressErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
-    ASSERT_EQ( -1, obhook_add_universal(0x0000000000000000, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_universal(0x0000000000000000, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_ADDR, obhook_errno );
 }
 TEST( AddUnivHookTest, LongLabelErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
-    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_LABEL, obhook_errno );
 }
 TEST( AddUnivHookTest, InvalidCallbackErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
-    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", NULL) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", NULL, NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_CALLBACK, obhook_errno );
 }
 TEST( AddUnivHookTest, MemoryErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillOnce( ReturnNull() );
-    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).Times(2).WillOnce( Invoke(calloc) ).WillOnce( ReturnNull() );
-    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 }
 TEST( AddUnivHookTest, NormalCondition ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    ASSERT_EQ( 0, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( 0, obhook_add_universal(0xffffffffffffffff, "label", dummy_cb, NULL) );
 }
 
 TEST( AddProcHookTest, InvalidCR3ErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
-    ASSERT_EQ( -1, obhook_add_process(0, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_process(0, 0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_CR3, obhook_errno );
 }
 TEST( AddProcHookTest, FullHookErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Return(-1) );
-    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_FULL_HOOK, obhook_errno );
 }
 TEST( AddProcHookTest, LongLabelErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
-    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "toooooooooooooo_long_label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_LABEL, obhook_errno );
 }
 TEST( AddProcHookTest, InvalidCallbackErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
-    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", NULL) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", NULL, NULL) );
     ASSERT_EQ( OBHOOK_ERR_INVALID_CALLBACK, obhook_errno );
 }
 TEST( AddProcHookTest, MemoryErrorHandle ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillOnce( ReturnNull() );
-    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).Times(2).WillOnce( Invoke(calloc) ).WillOnce( ReturnNull() );
-    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_EQ( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb, NULL) );
     ASSERT_EQ( OBHOOK_ERR_FAIL, obhook_errno );
 }
 TEST( AddProcHookTest, NormalConditionWithUserAddr ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0x0000ffffffffffff, "label", dummy_cb) );
+    ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0x0000ffffffffffff, "label", dummy_cb, NULL) );
 }
 TEST( AddProcHookTest, NormalConditionWithKernAddr ) {
     GEN_MOCK_OBJECT( mock );
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb) );
+    ASSERT_NE( -1, obhook_add_process(0x1234567812345678, 0xffffffffffffffff, "label", dummy_cb, NULL) );
 }
 
 TEST( GetUnivHookTest, HookFound ) {
@@ -194,7 +194,7 @@ TEST( GetUnivHookTest, HookFound ) {
     // register a new universal hook
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    hook_d = obhook_add_universal( addr, label, dummy_cb );
+    hook_d = obhook_add_universal( addr, label, dummy_cb, NULL );
     ASSERT_NE( -1, hook_d );
 
     // get the hook & check record
@@ -224,7 +224,7 @@ TEST( GetProcHookTest, HookFound ) {
     // register a new process hook
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    hook_d = obhook_add_process( cr3, addr, label, dummy_cb );
+    hook_d = obhook_add_process( cr3, addr, label, dummy_cb, NULL );
     ASSERT_NE( -1, hook_d );
 
     // get the hook & check record
@@ -247,7 +247,7 @@ TEST( GetProcHookTest, HookNotFound ) {
     // register a new process hook
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    ASSERT_NE( -1, obhook_add_process(cr3, addr, label, dummy_cb) );
+    ASSERT_NE( -1, obhook_add_process(cr3, addr, label, dummy_cb, NULL) );
 
     ASSERT_EQ( NULL, obhook_getcbs_proc(cr3 + 1, addr) );
     ASSERT_EQ( NULL, obhook_getcbs_proc(cr3, addr + 1) );
@@ -270,7 +270,7 @@ TEST( ToggleHookTest, HookDisableAndEnable ) {
     // register a new universal hook
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
-    hook_d = obhook_add_universal( addr, label, dummy_cb );
+    hook_d = obhook_add_universal( addr, label, dummy_cb, NULL );
     ASSERT_NE( -1, hook_d );
 
     // get the hook
@@ -326,7 +326,7 @@ TEST( DeleteHookTest, NormalCondition ) {
     EXPECT_CALL( mock, get_obhook_descriptor() ).WillOnce( Invoke(_get_obhook_descriptor) );
     EXPECT_CALL( mock, calloc(_,_) ).WillRepeatedly( Invoke(calloc) );
     
-    hook_d = obhook_add_process( cr3, addr, "to_be_deleted", dummy_cb );
+    hook_d = obhook_add_process( cr3, addr, "to_be_deleted", dummy_cb, NULL );
     ASSERT_NE( -1, hook_d );
     ASSERT_TRUE( obhk_ctx->index_tbl[hook_d] != NULL );
     

--- a/ext/systrace/systrace-commands-spec.h
+++ b/ext/systrace/systrace-commands-spec.h
@@ -1,0 +1,42 @@
+/*
+    //$LogFile
+ *  MBA System Call Tracer QEMU command specification 
+ *
+ *  Copyright (c)   2016 Chiawei Wang
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+{
+        .name      = "mba_add_systrace",
+        .args_type = "label:s,cr3:l,sycall_num:i",
+        .params    = "label cr3 sycall_num",
+        .help      = "Trace `sycall_num` system call for process with `cr3`",
+        .mhandler.cmd = do_add_systrace,
+},
+{
+        .name      = "mba_delete_systrace",
+        .args_type = "id:i",
+        .params    = "id",
+        .help      = "Delete the syscall tracer with given id",
+        .mhandler.cmd = do_delete_systrace,
+},
+{
+        .name      = "mba_list_systrace",
+        .args_type = "",
+        .params    = "",
+        .help      = "List all systrace",
+        .mhandler.cmd = do_list_systrace,
+},
+

--- a/ext/systrace/systrace-commands.c
+++ b/ext/systrace/systrace-commands.c
@@ -1,0 +1,52 @@
+/*
+ *  MBA System Call Tracer qemu command implementation
+ *
+ *  Copyright (c)   2016 Hao Li
+ *                  2016 Chiawei Wang
+ *                  2016 Chongkuan Chen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu-common.h"
+#include "monitor/monitor.h"
+
+#include "systrace-commands.h"
+#include "systrace.h"
+#include "systrace_priv.h"
+
+void do_add_systrace(Monitor *mon, const QDict *qdict)
+{
+    const char* label = qdict_get_str(qdict, "label");
+    uint64_t cr3 = qdict_get_int(qdict, "cr3"); 
+    int syscall_num = qdict_get_int(qdict, "sycall_num");
+    int handle = -1;
+    monitor_printf(mon, "Create systracer '%s': cr3 %016lx, syscall %d\n", label, cr3, syscall_num);
+    handle = systrace_add( label, cr3, syscall_num, cb_log_syscall_info, NULL );
+    monitor_printf(mon, "Creation finished, hadle = %d\n", handle);
+}
+
+void do_delete_systrace(Monitor *mon, const QDict *qdict)
+{
+    int id = qdict_get_int(qdict, "id");
+    int ret = 0;
+    ret = systrace_delete(id);
+    monitor_printf(mon, "Delete systracer id %d ret %d \n", id, ret);
+}
+
+void do_list_systrace(Monitor *mon, const QDict *qdict)
+{
+    systrace_list();
+}
+

--- a/ext/systrace/systrace-commands.h
+++ b/ext/systrace/systrace-commands.h
@@ -1,0 +1,11 @@
+#ifndef __SYSTRACE_COMMANDS_H__
+#define __SYSTRACE_COMMANDS_H__
+
+struct Monitor;
+struct QDict;
+
+void do_add_systrace(Monitor *mon, const QDict *qdict);
+void do_delete_systrace(Monitor *mon, const QDict *qdict);
+void do_list_systrace(Monitor *mon, const QDict *qdict);
+
+#endif

--- a/ext/systrace/systrace.c
+++ b/ext/systrace/systrace.c
@@ -1,0 +1,192 @@
+/*
+ *  System Call Trace header
+ *
+ *  Copyright (c)   2016 Hao Li
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#include "systrace.h"
+#include "systrace_priv.h"
+
+#include "cpu.h"
+#include "utlist.h"
+#include "utarray.h"
+#include "ext/obhook/obhook.h"
+
+#define MAX_NM_SYSTRACE 65536
+#define MAX_SZ_SYSTRACE_LABEL 16
+
+#define SUCCEED() do{return 0;}while( 0 )
+// XXX: INVALID_HANDLE also -1, implicit mix used
+#define FAIL( x ) do{systrace_errno = x; return -1;}while( 0 )
+
+SYSTRACE_ERRNO systrace_errno;
+
+typedef struct systrace_record{
+    int id;
+
+    // Label for user to reconize the systrace
+    char label[MAX_SZ_SYSTRACE_LABEL];
+
+    // the number of the system call to trace
+    int           syscall_number;
+
+    // the callback, invoked with X86CPU, is_invoked, user_argument
+    systrace_cb   callback;
+
+    // target cr3, trace all process if CR3_ALL
+    target_ulong  cr3;
+
+    // user argument for callback
+    void         *cb_args;
+
+    // linked list token
+    struct systrace_record *next;
+
+} systrace_record;
+
+struct {
+    // table of records, NULL if not occupied
+    systrace_record *records[MAX_NM_SYSTRACE];
+
+    // linked list of records
+    systrace_record *ll_records;
+
+} sys_ctx[1];
+
+static systrace_record *new_record( int id, const char* label, target_ulong cr3, int syscall_number, systrace_cb callback, void *cb_args ) {
+    systrace_record *rec = ( systrace_record* )calloc( 1, sizeof(systrace_record) );
+    if( rec ) {
+        rec->id = id;
+        strncpy( rec->label, label, MAX_SZ_SYSTRACE_LABEL );
+        rec->syscall_number = syscall_number;
+        rec->callback = callback;
+        rec->cr3 = cr3;
+        rec->cb_args = cb_args;
+    }
+    return rec;
+}
+
+// syscall enter/exit event handler
+static void event_callret( CPUX86State *env, bool is_enter ) {
+    X86CPU *x86cpu = ( X86CPU* )x86_env_get_cpu( env );
+    systrace_record *rec;
+    target_ulong syscall_number;
+    
+    // get system call number from register
+    syscall_number = env->regs[R_EAX] & 0xffff;
+    
+    // invoke all callbacks matching cr3 and system call number
+    LL_FOREACH( sys_ctx->ll_records, rec ) {
+        if( rec->cr3 == CR3_ALL || rec->cr3 == env->cr[3] ) {
+            if (is_enter) {
+                if( rec->syscall_number == SYSCALL_ALL || rec->syscall_number == syscall_number )
+                    rec->callback( x86cpu, true, rec->cb_args );
+            }
+            else {
+                // TODO: tell syscall number and call rec->callback
+            }
+        }
+    }
+}
+
+extern int systrace_add( const char* label, target_ulong target_cr3, int target_syscall_number, systrace_cb callback, void* cb_args ) {
+    int new_handle;
+    systrace_record *rec;
+
+    // get empty slot for new tracer
+    for( new_handle = 0; new_handle < MAX_NM_SYSTRACE; new_handle++ )
+        if( sys_ctx->records[new_handle] == NULL )
+            break;
+
+    if( new_handle == MAX_NM_SYSTRACE )
+        FAIL( SYSTRACE_ERR_FULL_TRACE );
+
+    // alloc new record
+    rec = new_record( new_handle, label, target_cr3, target_syscall_number, callback, cb_args );
+    if( rec == NULL )
+        FAIL( SYSTRACE_ERR_CREATE_FAIL );
+
+    // insert new record into list and occupy a table slot
+    LL_APPEND( sys_ctx->ll_records, rec );
+    sys_ctx->records[new_handle] = rec;
+
+    return new_handle;
+}
+
+extern int systrace_delete( int systrace_handle ) {
+    systrace_record *rec;
+    systrace_record *tmp;
+    systrace_record *target_rec;
+    
+    // get corresponding record of given handle
+    target_rec = sys_ctx->records[systrace_handle];
+
+    if( target_rec == NULL ) {
+        FAIL( SYSTRACE_ERR_INVALID_HANDLE );
+    }
+
+    // remove record from list, freeing the record and its content
+    LL_FOREACH_SAFE( sys_ctx->ll_records, rec, tmp ) {
+        if( rec != target_rec )
+            continue;
+
+        LL_DELETE( sys_ctx->ll_records, rec );
+
+        sys_ctx->records[systrace_handle] = NULL;
+        free( rec );
+        SUCCEED();
+    }
+
+    // record not in list
+    FAIL( SYSTRACE_ERR_INTERNAL_BROKEN );
+}
+
+extern int systrace_list(void) {
+    systrace_record *rec;
+    systrace_record *tmp;
+ 
+    printf("List all systrace\n");
+    LL_FOREACH_SAFE( sys_ctx->ll_records, rec, tmp ) {
+        printf("\tID: %d, LABEL: %s, SYSNUM: %d, CR3: %016lx, CB: %p\n", 
+              rec->id, rec->label, rec->syscall_number, rec->cr3, rec->callback);
+    }
+    SUCCEED();
+}
+
+
+// private api for implementation
+extern void systrace_on_syscall( CPUX86State *env ) {
+    return event_callret( env, true );
+}
+
+// private api for implementation
+extern void systrace_on_sysret( CPUX86State *env ) {
+    return event_callret( env, false );
+}
+
+// callback of systrace for dumping general syscall info
+void cb_log_syscall_info( X86CPU *x86cpu, bool is_invoke, void *args ) {
+    int errcode = 0;
+
+    // write invocation log to 'jo_out'
+    if( is_invoke ) {
+        printf( "syscall #%04lx invoked\n", x86cpu->env.regs[R_EAX] & 0xffff );
+    }
+
+    if( errcode == -1 ) {
+        printf( "syscall hook routine error\n" );
+    }
+}
+

--- a/ext/systrace/systrace.h
+++ b/ext/systrace/systrace.h
@@ -1,0 +1,75 @@
+/*
+ *  System Call Trace implementation
+ *
+ *  Copyright (c)   2016 Hao Li
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef __SYSTRACE_H__
+#define __SYSTRACE_H__
+#include "cpu.h"
+
+#define MAX_SERVICE_COUNT 441
+
+// system call numbers
+enum {
+    SYSCALL_ALL = -1,
+};
+
+// constants for special cr3 value
+enum {
+    CR3_ALL
+};
+
+// constants for special handle value
+enum {
+    INVALID_HANDLE = -1
+};
+typedef enum {
+    SYSTRACE_ERR_FAIL,
+    SYSTRACE_ERR_FULL_TRACE,
+    SYSTRACE_ERR_CREATE_FAIL,
+    SYSTRACE_ERR_INVALID_HANDLE,
+    SYSTRACE_ERR_INTERNAL_BROKEN,
+} SYSTRACE_ERRNO;
+extern SYSTRACE_ERRNO systrace_errno;
+
+// callback type 'systrace_cb' declaration
+typedef void ( *systrace_cb )( X86CPU*, bool is_invoke, void* args );
+
+// module APIs
+
+/// Add a system call trace, either process aware or not,
+/// for one specific or all system calls
+///
+///     \param  cr3      CR3 value of the targeted process, CR3_ALL for universal trace
+///     \param  syscall  address to implant the trace, SYSCALL_ALL for all system calls
+///     \param  callback callback routine to be invoked when the given system call is called
+///     \param  cb_args  argument for the given callback routine, simply copy by value
+///
+/// Return a new systrace descriptor on success, otherwise -1 is returned and the systrace_errno is set
+extern int systrace_add( const char* label, target_ulong cr3, int syscall, systrace_cb callback, void *cb_args );
+
+/// Delete a system call trace, given handle from systrace_add
+///
+///     \param  systrace_handle handle that represents the deleting trace
+///
+/// Return 0 on success, otherwise -1 is returned and the systrace_errno is set
+extern int systrace_delete( int systrace_handle );
+
+/// List all the trace
+///
+/// Return 0 on success, otherwise -1 is returned and the systrace_errno is set
+extern int systrace_list(void);
+#endif

--- a/ext/systrace/systrace_priv.h
+++ b/ext/systrace/systrace_priv.h
@@ -1,0 +1,10 @@
+#ifndef __SYSTRACE_PRIV_H__
+#define __SYSTRACE_PRIV_H__
+
+#include "cpu.h"
+
+extern void systrace_on_syscall(CPUX86State *env);
+extern void systrace_on_sysret(CPUX86State *env);
+extern void cb_log_syscall_info( X86CPU *x86cpu, bool is_invoke, void *args );
+
+#endif

--- a/ext/tracer/test/tracer_unittest.cc
+++ b/ext/tracer/test/tracer_unittest.cc
@@ -2,6 +2,7 @@
  *  MBA Mmemory Forensic unit testing
  *
  *  Copyright (c) 2016 Chong-kuan, Chen
+ *                2017 Jui-Chien, Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -75,7 +76,7 @@ TEST( TRACER_NOTEST, NormalCondition ) {
 
 class TRACER_INST_TRACER : public TracerContextInitialized{}; 
 TEST( TRACER_INST_TRACER, ADD_PROC_TRACER ){
-    int ret = tracer_add_inst_tracer( 0x331d0000, "test", false, NULL);
+    int ret = tracer_add_inst_tracer( 0x331d0000, "test", false, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_FALSE( tracer_ctx.process_tracer_head == NULL );
@@ -90,7 +91,7 @@ TEST( TRACER_INST_TRACER, ADD_PROC_TRACER ){
 }
 
 TEST( TRACER_INST_TRACER, ADD_PROC_TRACER2 ){
-    int ret = tracer_add_inst_tracer( 0x331d0000, "test", true, NULL);
+    int ret = tracer_add_inst_tracer( 0x331d0000, "test", true, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_FALSE( tracer_ctx.process_tracer_head == NULL );
@@ -106,7 +107,7 @@ TEST( TRACER_INST_TRACER, ADD_PROC_TRACER2 ){
 
 
 TEST( TRACER_INST_TRACER, ADD_UNIV_TRACER ){
-    int ret = tracer_add_inst_tracer( 0, "test", false, NULL);
+    int ret = tracer_add_inst_tracer( 0, "test", false, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_TRUE( tracer_ctx.process_tracer_head == NULL );
@@ -121,7 +122,7 @@ TEST( TRACER_INST_TRACER, ADD_UNIV_TRACER ){
 }
 
 TEST( TRACER_INST_TRACER, ADD_NERNEL_UNIV_TRACER ){
-    int ret = tracer_add_inst_tracer( 0, "test", true, NULL);
+    int ret = tracer_add_inst_tracer( 0, "test", true, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_TRUE( tracer_ctx.process_tracer_head == NULL );
@@ -139,11 +140,11 @@ TEST( TRACER_INST_TRACER, ADD_MAXMUN_TRACER ){
     int ret;
     for(int i = 0; i< UINT16_MAX ; i++)
     {
-        ret = tracer_add_inst_tracer( 0, "test", true, NULL);
+        ret = tracer_add_inst_tracer( 0, "test", true, NULL, NULL);
         ASSERT_EQ( ret, i+1);
         //printf("%d\n", i);
     }
-    ret = tracer_add_inst_tracer( 0, "test", true, NULL);
+    ret = tracer_add_inst_tracer( 0, "test", true, NULL, NULL);
     ASSERT_EQ(ret, -1);
     ASSERT_EQ(g_error_no, TRACER_MAX_TRACER_ID);
 
@@ -151,10 +152,10 @@ TEST( TRACER_INST_TRACER, ADD_MAXMUN_TRACER ){
 }
 
 TEST( TRACER_INST_TRACER, ENABLE_TRACER ){
-    int ret = tracer_add_inst_tracer( 0, "test", true, NULL);
+    int ret = tracer_add_inst_tracer( 0, "test", true, NULL, NULL);
     int status;    
 
-    ASSERT_TRUE( ret != NULL);
+    ASSERT_TRUE( ret != -1 );
 
     status = tracer_get_tracer_status(ret);
     ASSERT_EQ(status, 0);
@@ -167,10 +168,10 @@ TEST( TRACER_INST_TRACER, ENABLE_TRACER ){
 }
 
 TEST( TRACER_INST_TRACER, DISABLE_TRACER ){
-    int ret = tracer_add_inst_tracer( 0, "test", true, NULL);
+    int ret = tracer_add_inst_tracer( 0, "test", true, NULL, NULL);
     int status;
 
-    ASSERT_TRUE( ret != NULL);
+    ASSERT_TRUE( ret != -1 );
 
     status = tracer_get_tracer_status(ret);
     ASSERT_EQ(status, 0);
@@ -188,7 +189,7 @@ TEST( TRACER_INST_TRACER, DISABLE_TRACER ){
 
 TEST( TRACER_INST_TRACER, GET_TRACER_LABEL ){
     const char* label_string = "test"; 
-    int ret = tracer_add_inst_tracer( 0, label_string, true, NULL);
+    int ret = tracer_add_inst_tracer( 0, label_string, true, NULL, NULL);
     char* label = tracer_get_tracer_label(ret);
     ASSERT_EQ( strcmp(label_string, label) , 0);
 
@@ -197,7 +198,7 @@ TEST( TRACER_INST_TRACER, GET_TRACER_LABEL ){
 
 TEST( TRACER_INST_TRACER, LONG_TRACER_LABEL ){
     const char* label_string = "testtesttestetsetestestestsetsestsetsestestsestsestestsetsest";
-    int ret = tracer_add_inst_tracer( 0, label_string, true, NULL);
+    int ret = tracer_add_inst_tracer( 0, label_string, true, NULL, NULL);
     char* label = tracer_get_tracer_label(ret);
     ASSERT_NE( strcmp(label_string, label) , 0);
     tracer_clean_up();
@@ -206,7 +207,7 @@ TEST( TRACER_INST_TRACER, LONG_TRACER_LABEL ){
 /****************************************************************************/
 class TRACER_BLOCK_TRACER : public TracerContextInitialized{};
 TEST( TRACER_BLOCK_TRACER, ADD_BLOCK_TRACER ){
-    int ret = tracer_add_block_tracer( 0x331d0000, "test", false, NULL);
+    int ret = tracer_add_block_tracer( 0x331d0000, "test", false, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_TRUE( tracer_ctx.process_tracer_head == NULL );
@@ -221,7 +222,7 @@ TEST( TRACER_BLOCK_TRACER, ADD_BLOCK_TRACER ){
 }
 
 TEST( TRACER_BLOCK_TRACER, ADD_BLOCK_TRACER2 ){
-    int ret = tracer_add_block_tracer( 0x331d0000, "test", true, NULL);
+    int ret = tracer_add_block_tracer( 0x331d0000, "test", true, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_TRUE( tracer_ctx.process_tracer_head == NULL );
@@ -237,7 +238,7 @@ TEST( TRACER_BLOCK_TRACER, ADD_BLOCK_TRACER2 ){
 
 
 TEST( TRACER_BLOCK_TRACER, ADD_UNIV_TRACER ){
-    int ret = tracer_add_block_tracer( 0, "test", false, NULL);
+    int ret = tracer_add_block_tracer( 0, "test", false, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_TRUE( tracer_ctx.process_tracer_head == NULL );
@@ -252,7 +253,7 @@ TEST( TRACER_BLOCK_TRACER, ADD_UNIV_TRACER ){
 }
 
 TEST( TRACER_BLOCK_TRACER, ADD_NERNEL_UNIV_TRACER ){
-    int ret = tracer_add_block_tracer( 0, "test", true, NULL);
+    int ret = tracer_add_block_tracer( 0, "test", true, NULL, NULL);
     ASSERT_EQ( ret, 1);
     //tracer_list_callback();
     ASSERT_TRUE( tracer_ctx.process_tracer_head == NULL );

--- a/ext/tracer/tracer-commands.c
+++ b/ext/tracer/tracer-commands.c
@@ -4,6 +4,7 @@
  *  Copyright (c)   2012 Chiwei Wang
  *                  2016 Chiawei Wang
  *                  2016 Chongkuan Chen
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -44,7 +45,7 @@ void do_inst_tracer(Monitor *mon, const QDict *qdict)
     const char* label = qdict_get_str(qdict, "label");
     uint64_t cr3 = qdict_get_int(qdict, "cr3");
     bool is_kernel = qdict_get_bool(qdict, "is_kernel");
-    tracer_add_inst_tracer(cr3, label, is_kernel, NULL); 
+    tracer_add_inst_tracer(cr3, label, is_kernel, NULL, NULL); 
 }
 
 void do_block_tracer(Monitor *mon, const QDict *qdict)
@@ -52,7 +53,7 @@ void do_block_tracer(Monitor *mon, const QDict *qdict)
     const char* label = qdict_get_str(qdict, "label");
     uint64_t cr3 = qdict_get_int(qdict, "cr3");
     bool is_kernel = qdict_get_bool(qdict, "is_kernel");
-    tracer_add_block_tracer(cr3, label, is_kernel, NULL);
+    tracer_add_block_tracer(cr3, label, is_kernel, NULL, NULL);
 }
 
 void do_list_tracer(Monitor *mon, const QDict *qdict)

--- a/ext/tracer/tracer-priv.h
+++ b/ext/tracer/tracer-priv.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (c)   2016 Chiawei Wang
  *                  2016 ChongKuan Chen
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -36,7 +37,7 @@ bool tracer_is_kern_addr( uint64_t addr );
 /// \param env_state		the cpu state
 /// \param pc_start		the start addess of block, or instruction
 /// \param pa_end		the end address of block, or 0 for instruction tracer
-void* default_callback(void* env_state, uint64_t pc_start, uint64_t pc_end );
+void* default_callback(void* env_state, uint64_t pc_start, uint64_t pc_end, void* arg );
 
 /// void tracer_list_callback(void);
 /// list all callback

--- a/ext/tracer/tracer.h
+++ b/ext/tracer/tracer.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (c)   2016 Chiawei Wang
  *                  2016 ChongKuan Chen
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -58,7 +59,8 @@ struct tracer_cb_record {
     // user-friendly label string
     char label[MAX_SZ_TRACER_LABEL];
 
-    void* (*cb_func) (void*,uint64_t, uint64_t);
+    void* (*cb_func) (void*,uint64_t, uint64_t, void*);
+    void* cb_arg;
 
     struct tracer_cb_record* next;
 };
@@ -115,7 +117,7 @@ extern int tracer_disable_tracer(int);
 ///                             instruction tracer(always be 0), and the cb must return void*
 /// 
 /// return -1 on error, tracer_id on success
-extern int tracer_add_inst_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t) );
+extern int tracer_add_inst_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t, void*), void* usr_cb_arg );
 
 /// int tracer_add_block_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t) );
 /// Add a new block level tracer
@@ -133,7 +135,7 @@ extern int tracer_add_inst_tracer( uint64_t cr3, const char* label, bool is_kern
 ///                             the cb must return void*, and the default call back is used when cb == NULL
 /// 
 /// return -1 on error, tracer_id on success
-extern int tracer_add_block_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t) );
+extern int tracer_add_block_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t, void*), void* usr_cb_arg );
 
 
 /// char* tracer_get_tracer_label(int uid)

--- a/ext/tracer/tracer.h
+++ b/ext/tracer/tracer.h
@@ -52,13 +52,14 @@ struct tracer_cb_record {
     int enabled;
     uint64_t cr3;
     bool is_universal;
-    //TODO: Add support for kernel trace 
+    // Identification for kernel trace 
     bool is_kernel_trace;
     int trace_granularity;
 
     // user-friendly label string
     char label[MAX_SZ_TRACER_LABEL];
 
+    // cb_arg is the user-defined argument, and will be passed as the fourth parameter of cb_func
     void* (*cb_func) (void*,uint64_t, uint64_t, void*);
     void* cb_arg;
 
@@ -88,7 +89,7 @@ extern tracer_context tracer_ctx;
 /// int tracer_enable_tracer(int uid)
 /// Enable the tracer by id 
 ///
-/// \param uid              	id of the target tracer
+///     \param uid              	id of the target tracer
 /// 
 /// return -1 on error, 0 on success
 extern int tracer_enable_tracer(int);
@@ -96,7 +97,7 @@ extern int tracer_enable_tracer(int);
 /// int tracer_disable_tracer(int);
 /// Disable the tracer by id 
 ///
-/// \param uid           	id of the target tracer
+///     \param uid           	id of the target tracer
 /// 
 /// return -1 on error, 0 on success
 extern int tracer_disable_tracer(int);
@@ -104,35 +105,37 @@ extern int tracer_disable_tracer(int);
 /// int tracer_add_inst_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t) );
 /// Add a new instruction level tracer
 ///
-/// \param cr3                  the target process which want to monitor	
-///                             if the cr3 is 0, then the tracer monitor all the process
-/// \param label                the name label for identifying the tracer, user can provide their own name
-/// \param is_kernel            denote if we want to trace kernel instructions, 
-///                             1 for kernel, 0 for user-level 
-/// \param cb                   the callback function after the instrction executed.
-///	                            cb must receive 3 arguments:
-///                                 1st is CPUX86State(user must convert it from void* to CPUX86State*) 
-///                                 2nd is start address of instruction
-///                                 3rd is useless in the default call back which is used when cb == NULL
-///                             instruction tracer(always be 0), and the cb must return void*
+///     \param cr3                  the target process which want to monitor	
+///                                 if the cr3 is 0, then the tracer monitor all the process
+///     \param label                the name label for identifying the tracer, user can provide their own name
+///     \param is_kernel            denote if we want to trace kernel instructions, 
+///                                 1 for kernel, 0 for user-level 
+///     \param cb                   the callback function after the instrction executed.
+///	                                cb must receive 3 arguments:
+///                                     1st is CPUX86State(user must convert it from void* to CPUX86State*) 
+///                                     2nd is start address of instruction
+///                                     3rd is useless in the default call back
+///                                 instruction tracer(always be 0), the cb must return void*, and the default call back is used when cb == NULL
+///     \param usr_cb_arg           user-defined argument that will be transmitted as the "fourth" parameter of callback function
 /// 
 /// return -1 on error, tracer_id on success
 extern int tracer_add_inst_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t, void*), void* usr_cb_arg );
 
 /// int tracer_add_block_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t) );
 /// Add a new block level tracer
-///
-/// \param cr3                  the target process which want to monitor        
-///                             if the cr3 is 0, then the tracer monitor all the process
-/// \param label                the name label for identifying the tracer, user can provide their own name
-/// \param is_kernel            denote if we want to trace kernel instructions, 
-///                             1 for kernel, 0 for user-level 
-/// \param cb                   The callback function after the instrction executed.
-///                             cb must receive 3 arguments:
-///                                 1st is CPUX86State(user must convert it from void* to CPUX86State*) 
-///                                 2nd is start address of block
-///                                 3rd is address of last ins of block 
-///                             the cb must return void*, and the default call back is used when cb == NULL
+///     
+///     \param cr3                  the target process which want to monitor        
+///                                 if the cr3 is 0, then the tracer monitor all the process
+///     \param label                the name label for identifying the tracer, user can provide their own name
+///     \param is_kernel            denote if we want to trace kernel instructions, 
+///                                 1 for kernel, 0 for user-level 
+///     \param cb                   The callback function after the instrction executed.
+///                                 cb must receive 3 arguments:
+///                                     1st is CPUX86State(user must convert it from void* to CPUX86State*) 
+///                                     2nd is start address of block
+///                                     3rd is address of last ins of block 
+///                                 the cb must return void*, and the default call back is used when cb == NULL
+///     \param usr_cb_arg           user-defined argument that will be transmitted as the "fourth" parameter of callback function
 /// 
 /// return -1 on error, tracer_id on success
 extern int tracer_add_block_tracer( uint64_t cr3, const char* label, bool is_kernel, void*(*cb) (void*, uint64_t, uint64_t, void*), void* usr_cb_arg );
@@ -141,7 +144,7 @@ extern int tracer_add_block_tracer( uint64_t cr3, const char* label, bool is_ker
 /// char* tracer_get_tracer_label(int uid)
 /// Return the label of tracer with uid
 ///
-/// \param uid                 the uid of target tracer       
+///     \param uid                 the uid of target tracer       
 /// 
 /// return NULL on error, tracer's label  on success
 extern char* tracer_get_tracer_label(int uid);
@@ -149,13 +152,14 @@ extern char* tracer_get_tracer_label(int uid);
 /// int tracer_get_tracer_status(int uid)
 /// Return the status of tracer with uid
 ///
-/// \param uid                 the uid of target tracer       
+///     \param uid                 the uid of target tracer       
 /// 
 /// return -1 on error, 1 for enable and 0 for disable
 extern int tracer_get_tracer_status(int uid);
 
 /// int get_error_no(void);
 /// get the error number 
+///
 /// return the int of enum TRACER_ERRNO
 extern int get_error_no(void);
 extern int tracer_clean_up(void);

--- a/include/disas/disas.h
+++ b/include/disas/disas.h
@@ -8,7 +8,7 @@
 void disas(FILE *out, void *code, unsigned long size);
 void target_disas(FILE *out, CPUArchState *env, target_ulong code,
                   target_ulong size, int flags);
-void target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
+int target_disas_inst_count(FILE *out, CPUArchState *env, target_ulong code,
                   target_ulong size, int num_inst, int flags);
 void monitor_disas(Monitor *mon, CPUArchState *env,
                    target_ulong pc, int nb_insn, int is_physical, int flags);

--- a/monitor.c
+++ b/monitor.c
@@ -110,6 +110,10 @@
 #include "ext/nettramon/nettramon-commands.h"
 #endif
 
+#if defined(CONFIG_SYSTRACE)
+#include "ext/systrace/systrace-commands.h"
+#endif
+
 #if defined(CONFIG_DBA)
 #include "ext/dba/dba-commands.h"
 #endif
@@ -3004,6 +3008,10 @@ static mon_cmd_t mon_cmds[] = {
 
 #if defined(CONFIG_NETTRAMON)
 #include "ext/nettramon/nettramon-commands-spec.h"
+#endif
+
+#if defined(CONFIG_SYSTRACE)
+#include "ext/systrace/systrace-commands-spec.h"
 #endif
 
 #if defined(CONFIG_DBA)

--- a/monitor.c
+++ b/monitor.c
@@ -5583,24 +5583,10 @@ void *mba_mon_get_cpu( void ) {
 // The following functions should check the setting mode by API
 void mba_readline_start( Monitor* mon, const char *prompt, int read_password,
                          ReadLineFunc *readline_func, void *opaque) {
-#if defined(CONFIG_DBA)
-    if ( !do_dba_config_file_setting() ) {
-        readline_start( mon->rs, prompt, read_password, readline_func, opaque );
-    }
-#endif
-#if !defined(CONFIG_DBA)
     readline_start( mon->rs, prompt, read_password, readline_func, opaque );
-#endif
 }
 
 void mba_readline_show_prompt( Monitor* mon ) {
-#if defined(CONFIG_DBA)
-    if ( !do_dba_config_file_setting() ) {
-        readline_show_prompt( mon->rs );
-    }
-#endif
-#if !defined(CONFIG_DBA)
     readline_show_prompt( mon->rs );
-#endif
 }
 

--- a/target-i386/mba_helper.c
+++ b/target-i386/mba_helper.c
@@ -42,7 +42,7 @@ void helper_obhook_dispatcher( CPUX86State* env ) {
     if( cb_list != NULL ) {
         LL_FOREACH( cb_list, cb_rec ) {
             if( cb_rec->enabled )
-                cb_rec->cb_func( ENV_GET_CPU(env) );
+                cb_rec->cb_func( ENV_GET_CPU(env), cb_rec->cb_arg );
         }
     }
 
@@ -51,7 +51,7 @@ void helper_obhook_dispatcher( CPUX86State* env ) {
     if( cb_list != NULL ) {
         LL_FOREACH( cb_list, cb_rec ) {
             if( cb_rec->enabled )
-                cb_rec->cb_func( ENV_GET_CPU(env) );
+                cb_rec->cb_func( ENV_GET_CPU(env), cb_rec->cb_arg );
         }
     }
 }

--- a/target-i386/mba_helper.c
+++ b/target-i386/mba_helper.c
@@ -3,6 +3,8 @@
  *      Out-of-Box Hook
  *
  *  Copyright (c)   2016 Chiawei Wang
+ *                  2016 ChongKuan Chen
+ *                  2017 JuiChien Jao
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -64,7 +66,7 @@ void helper_tracer_dispatcher( CPUX86State* env, uint64_t pc ) {
     if(tracer_ctx.process_tracer_head!=NULL && !tracer_is_kern_addr(pc)){
     	LL_FOREACH( tracer_ctx.process_tracer_head , cb_rec){
         	if( env->cr[3] == cb_rec->cr3 && cb_rec->enabled == 1){
-                	cb_rec->cb_func( ENV_GET_CPU(env), pc, 0 );
+                	cb_rec->cb_func( ENV_GET_CPU(env), pc, 0, cb_rec->cb_arg );
         	}
     	}
     }
@@ -72,14 +74,14 @@ void helper_tracer_dispatcher( CPUX86State* env, uint64_t pc ) {
     if( tracer_ctx.universal_kernel_tracer_head!=NULL && tracer_is_kern_addr(pc) ){
             LL_FOREACH( tracer_ctx.universal_kernel_tracer_head , cb_rec){
             if(cb_rec->enabled == 1)
-                cb_rec->cb_func( ENV_GET_CPU(env), pc, 0 );
+                cb_rec->cb_func( ENV_GET_CPU(env), pc, 0, cb_rec->cb_arg  );
         }
     }
 
     if( tracer_ctx.universal_tracer_head!=NULL && !tracer_is_kern_addr(pc) ){
             LL_FOREACH( tracer_ctx.universal_tracer_head , cb_rec){
             if(cb_rec->enabled == 1)
-                cb_rec->cb_func( ENV_GET_CPU(env), pc, 0 );
+                cb_rec->cb_func( ENV_GET_CPU(env), pc, 0, cb_rec->cb_arg  );
         }
     }    
 }
@@ -90,21 +92,21 @@ void helper_btracer_dispatcher( CPUX86State* env, uint64_t bstart, uint64_t bend
     if( tracer_ctx.process_btracer_head!=NULL && !tracer_is_kern_addr(bstart) ){
             LL_FOREACH( tracer_ctx.process_btracer_head , cb_rec){
             if(env->cr[3] == cb_rec->cr3  && cb_rec->enabled == 1)
-                cb_rec->cb_func( ENV_GET_CPU(env), bstart, bend );
+                cb_rec->cb_func( ENV_GET_CPU(env), bstart, bend, cb_rec->cb_arg  );
         }
     }
 
     if( tracer_ctx.universal_kernel_btracer_head!=NULL && tracer_is_kern_addr(bstart) ){
             LL_FOREACH( tracer_ctx.universal_kernel_btracer_head , cb_rec){
             if(cb_rec->enabled == 1)
-                cb_rec->cb_func( ENV_GET_CPU(env), bstart, bend );
+                cb_rec->cb_func( ENV_GET_CPU(env), bstart, bend, cb_rec->cb_arg  );
         }
     }
 
     if( tracer_ctx.universal_btracer_head!=NULL && !tracer_is_kern_addr(bstart) ){
             LL_FOREACH( tracer_ctx.universal_btracer_head , cb_rec){
             if(cb_rec->enabled == 1)
-                cb_rec->cb_func( ENV_GET_CPU(env), bstart, bend );
+                cb_rec->cb_func( ENV_GET_CPU(env), bstart, bend, cb_rec->cb_arg  );
         }
     }
 }

--- a/target-i386/seg_helper.c
+++ b/target-i386/seg_helper.c
@@ -23,6 +23,9 @@
 #include "exec/helper-proto.h"
 #include "exec/cpu_ldst.h"
 
+#ifdef CONFIG_SYSTRACE
+#include "ext/systrace/systrace_priv.h"
+#endif
 //#define DEBUG_PCALL
 
 #ifdef DEBUG_PCALL
@@ -956,9 +959,14 @@ void helper_syscall(CPUX86State *env, int next_eip_addend)
     cpu_loop_exit(cs);
 }
 #else
+
 void helper_syscall(CPUX86State *env, int next_eip_addend)
 {
     int selector;
+
+#ifdef CONFIG_SYSTRACE
+    systrace_on_syscall(env);
+#endif
 
     if (!(env->efer & MSR_EFER_SCE)) {
         raise_exception_err(env, EXCP06_ILLOP, 0);
@@ -1014,6 +1022,10 @@ void helper_syscall(CPUX86State *env, int next_eip_addend)
 void helper_sysret(CPUX86State *env, int dflag)
 {
     int cpl, selector;
+
+#ifdef CONFIG_SYSTRACE
+    systrace_on_sysret(env);
+#endif
 
     if (!(env->efer & MSR_EFER_SCE)) {
         raise_exception_err(env, EXCP06_ILLOP, 0);


### PR DESCRIPTION
## TRACER and OBHOOK 
1. TRACER allows callback function to pass an argument defined by user now.
2. OBHOOK allows callback function to pass an argument defined by user now.
3. Test cases of both of TRACER and OBHOOK have been revised.

## DBA
### The results of DBA tasks with tracer ability are expected to be written into files.
### Tracer ability
1. DBA module now has tracer ability as dba/dba_tracer.h and dba/dba_tracer.c.
### User Interface
- Tracer Ability
1. Questions of loading structure definition and global variable JSON files have been added to the DBA setting and DBA API.
- Taint Ability
1. The tainted packet question has been added to the DBA setting ( User should turn on NTM manually before this commit, but NTM will be turned on if it's needed now ).
### DBA Configuration
- dba_config_sample
1. The dba_config_sample has been updated according to this commit.
- Taint Ability
1. User can specify the files to write the captured packets in the tags under the "NETTRAMON".
2. "PACKET" and "TAG" will be ignored if the "ENABLE" tag of "TAINT" is "no".
- Tracer Ability
1. User can specify the files for structure definition and global variable JSON files under the "TRACER" tag.
2. "ENABLE" under "TRACER is the master switch of TRACER ability and config parser will ignore all the setting below if it is "no".
### DBA user interface setting sequence goes as:
**"TAINT"** ( -> "PACKET" -> "tag" ) -> **"SYSCALL"** -> **"TRACER"** [ ( -> "LOAD STRUCTURE" -> "LOAD GLOBALVAR" ) -> "INSTRUCTION" ( -> "IS_KERNEL" ) -> "BLOCK" ( -> "IS_KERNEL" ) ] -> "CONFIRM"
### DBA config file setting sequence goes as:
**"MODULES"** -> "AGENT" -> "DIFT" -> "NETTRAMON" ( -> "ALL" -> "TCP" -> "UDP" -> "ICMP" ) -> **"TAINT"** ( -> "PACKET" -> "tag" ) -> **"SYSCALL"** -> **"TRACER"** [ ( -> "LOAD STRUCTURE" -> "LOAD GLOBALVAR" ) -> "INSTRUCTION" ( -> "IS_KERNEL" ) -> "BLOCK" ( -> "IS_KERNEL" ) ] -> "CONFIRM"