### PR TITLE
Agent Module Bug Fixed

### DIFF
--- a/ext/agent/agent.c
+++ b/ext/agent/agent.c
@@ -140,7 +140,7 @@ static ssize_t _MOCKABLE(as_write)( int sock_fd, void* buf, size_t count ) {
 /// Return bytes read, <= 0 if any error occured
 static ssize_t _MOCKABLE(as_read)( int sock_fd, void* buf, size_t count ) {
 
-    socklen_t length;
+    socklen_t length = sizeof(ac->serveraddr);
     ssize_t n_rbytes = recvfrom( sock_fd, buf, count, 0, (struct sockaddr*)&ac->serveraddr, &length );
 
     // 0: connection orderly closed, -1: error


### PR DESCRIPTION
### Fixed Agent Bug issued by #48
1. Fix the bug triggered by no giving definition to the "length" in function "as_read" in ext/agent/agnet.c.
   1.1. This would make the value of "length" be undeterministic,
        and error 22 would occur when the value is smaller than "sizeof(ac->serveraddr)".