### PR TITLE
Revise the DIFT extension

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -494,13 +494,10 @@ int cpu_exec(CPUArchState *env)
                 if( dift_code_top + 10000 > CONFIG_MAX_TB_ESTI )
                     tb_flush( env );
 
-                // if a pending DIFT switch on/off, flush the 
-                // translated code blocks and flip the DIFT status
+                // if a pending DIFT switch on/off, 
+                // flush the translated code blocks
                 if( dift_switch_pending ) {
-
                     tb_flush( env );
-
-                    dift_enabled = !dift_enabled;
                     dift_switch_pending = false;
                 }
 #endif

--- a/ext/dift/dift-policy.h
+++ b/ext/dift/dift-policy.h
@@ -1086,7 +1086,7 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    set_mem_dirty(dc, wa, dc->reg_dirty_tbl[i][k], 0);
+    set_mem_dirty(dc, wa, 1, dc->reg_dirty_tbl[i][k], false);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1228,7 +1228,7 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    set_mem_dirty(dc, wa, dc->reg_dirty_tbl[i][k], 1);
+    set_mem_dirty(dc, wa, 1, dc->reg_dirty_tbl[i][k], true);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1370,8 +1370,7 @@ DIFT_DEBUG_CONDITION
 
     t = dc->reg_dirty_tbl[i][0] | dc->reg_dirty_tbl[i][1];
 
-    set_mem_dirty(dc, wa, t, 0);
-    set_mem_dirty(dc, wa + 1, t, 0);
+    set_mem_dirty(dc, wa, 2, t, false);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1409,10 +1408,7 @@ DIFT_DEBUG_CONDITION
     t =   dc->reg_dirty_tbl[i][0] | dc->reg_dirty_tbl[i][1]
         | dc->reg_dirty_tbl[i][2] | dc->reg_dirty_tbl[i][3];
 
-    set_mem_dirty(dc, wa, t, 0);
-    set_mem_dirty(dc, wa + 1, t, 0);
-    set_mem_dirty(dc, wa + 2, t, 0);
-    set_mem_dirty(dc, wa + 3, t, 0);
+    set_mem_dirty(dc, wa, 4, t, false);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1452,14 +1448,7 @@ DIFT_DEBUG_CONDITION
         | dc->reg_dirty_tbl[i][4] | dc->reg_dirty_tbl[i][5]
         | dc->reg_dirty_tbl[i][6] | dc->reg_dirty_tbl[i][7];
 
-    set_mem_dirty(dc, wa,     t, 0);
-    set_mem_dirty(dc, wa + 1, t, 0);
-    set_mem_dirty(dc, wa + 2, t, 0);
-    set_mem_dirty(dc, wa + 3, t, 0);
-    set_mem_dirty(dc, wa + 4, t, 0);
-    set_mem_dirty(dc, wa + 5, t, 0);
-    set_mem_dirty(dc, wa + 6, t, 0);
-    set_mem_dirty(dc, wa + 7, t, 0);
+    set_mem_dirty(dc, wa, 8, t, false);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1497,8 +1486,7 @@ DIFT_DEBUG_CONDITION
     t = dc->reg_dirty_tbl[i][0] | dc->reg_dirty_tbl[i][1]
         | get_mem_dirty(dc, wa) | get_mem_dirty(dc, wa + 1);
 
-    set_mem_dirty(dc, wa, t, 1);
-    set_mem_dirty(dc, wa + 1, t, 1);
+    set_mem_dirty(dc, wa, 2, t, true);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1538,10 +1526,7 @@ DIFT_DEBUG_CONDITION
         | get_mem_dirty(dc, wa)     | get_mem_dirty(dc, wa + 1)
         | get_mem_dirty(dc, wa + 2) | get_mem_dirty(dc, wa + 3);
 
-    set_mem_dirty(dc, wa,     t, 1);
-    set_mem_dirty(dc, wa + 1, t, 1);
-    set_mem_dirty(dc, wa + 2, t, 1);
-    set_mem_dirty(dc, wa + 3, t, 1);
+    set_mem_dirty(dc, wa, 4, t, true);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -1585,14 +1570,7 @@ DIFT_DEBUG_CONDITION
         | get_mem_dirty(dc, wa + 4) | get_mem_dirty(dc, wa + 5)
         | get_mem_dirty(dc, wa + 6) | get_mem_dirty(dc, wa + 7);
 
-    set_mem_dirty(dc, wa,     t, 1);
-    set_mem_dirty(dc, wa + 1, t, 1);
-    set_mem_dirty(dc, wa + 2, t, 1);
-    set_mem_dirty(dc, wa + 3, t, 1);
-    set_mem_dirty(dc, wa + 4, t, 1);
-    set_mem_dirty(dc, wa + 5, t, 1);
-    set_mem_dirty(dc, wa + 6, t, 1);
-    set_mem_dirty(dc, wa + 7, t, 1);
+    set_mem_dirty(dc, wa, 8, t, true);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -2907,8 +2885,7 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    for( i = 0 ; i < l ; ++i )
-        set_mem_dirty( dc, wa + i, j, 1 );
+    set_mem_dirty( dc, wa, l, j, true );
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -2936,8 +2913,7 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    for( i = 0 ; i < l ; ++i )
-        and_mem_dirty( dc, wa + i, j );
+    and_mem_dirty( dc, wa, l, j );
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -2964,8 +2940,8 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    for(i = 0 ; i < l ; i++)
-        set_hd_dirty_or(dc, hdaddr + i, j);
+    //for(i = 0 ; i < l ; i++)
+    set_hd_dirty_or(dc, hdaddr, l, j);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -2992,8 +2968,7 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    for(i = 0 ; i < l ; i++)
-        set_hd_dirty_and(dc, hdaddr + i, j);
+    set_hd_dirty_and(dc, hdaddr, l, j);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
@@ -3019,8 +2994,7 @@ DIFT_DEBUG_CONDITION
 }
 #endif
 
-    for(i = 0; i < l; i++)
-        set_mem_dirty(dc, wa + i, 0, 0);
+    set_mem_dirty(dc, wa, l, 0, false);
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION

--- a/ext/dift/dift.c
+++ b/ext/dift/dift.c
@@ -1295,13 +1295,17 @@ CONTAMINATION_RECORD dift_get_disk_dirty( uint64_t haddr ) {
 }
 
 void dift_enable( void ) {
-    if( !dift_enabled )
+    if( !dift_enabled ) {
+        dift_enabled = !dift_enabled;
         dift_switch_pending = true;
+    }
 }
 
 void dift_disable( void ) {
-    if( dift_enabled )
+    if( dift_enabled ) {
+        dift_enabled = !dift_enabled;
         dift_switch_pending = true;
+    }
 }
 
 bool dift_is_enabled( void ) {

--- a/ext/dift/dift.c
+++ b/ext/dift/dift.c
@@ -661,10 +661,9 @@ static void _MOCKABLE(pre_generate_routine)( void ) {
 
     result = mprotect((void*)start, end - start,
             PROT_READ | PROT_WRITE | PROT_EXEC);
-    if (result != 0) {
-#if defined(CONFIG_DIFT_DEBUG)
+
+    if( result != 0 ) {
         dift_log( "mprotect failed\n" );
-#endif
         exit(1);
     }
 }
@@ -778,7 +777,19 @@ static void _MOCKABLE(wait_dift_analysis)( void ) {
     while( !dift_thread_ok_signal );
 }
 
-static int _MOCKABLE(is_valid_mem_range)( uint64_t addr, uint64_t len ) {
+// DIFT Private API - taint operand validity check
+static bool _MOCKABLE(is_valid_tag)( const CONTAMINATION_RECORD tag ) {
+
+    CONTAMINATION_RECORD mask = 0x7f;
+
+    // DIFT support only the 7 least significant bits as the taint tag
+    // the most significant tag is preserved
+    if( (tag & (~mask)) != 0 )
+        return false;
+    return true;
+}
+
+static bool _MOCKABLE(is_valid_mem_range)( uint64_t addr, uint64_t len ) {
 
     if( 
         (phys_ram_size < addr || phys_ram_size - addr < len)
@@ -789,39 +800,61 @@ static int _MOCKABLE(is_valid_mem_range)( uint64_t addr, uint64_t len ) {
 
     return true;
 }
+
+static bool _MOCKABLE(is_valid_disk_range)( uint64_t haddr, uint64_t len ) {
+
+    if( HD_MAX_SIZE < haddr || HD_MAX_SIZE - haddr < len )
+        return false;
+    return true;
+}
+
 // DIFT Private API - Memory taint operation
-static inline void set_mem_dirty( dift_context* dc, uint64_t addr, CONTAMINATION_RECORD contamination, int is_append ) {
+static inline DIFT_STATUS set_mem_dirty( dift_context* dc, uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag, bool is_append ) {
 
-    if( !is_valid_mem_range(addr, 1) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "set_mem_dirty: invalid address" );
-#endif
-        return;
+    if( !is_valid_mem_range(addr, len) ) {
+        dift_log( "set_mem_dirty: out of range, addr=%16lx, len=%16lx\n", addr, len );
+        return DIFT_ERR_OUTOFRANGE;
     }
 
-    if( is_append )
-        dc->mem_dirty_tbl[addr] |= contamination;
-    else
-        dc->mem_dirty_tbl[addr]  = contamination;
-}
-
-static inline void and_mem_dirty( dift_context* dc, uint64_t addr, CONTAMINATION_RECORD contamination ) {
-    if( !is_valid_mem_range(addr, 1) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "and_mem_dirty: invalid address" );
-#endif
-        return;
+    if( !is_valid_tag(tag) ) {
+        dift_log( "set_mem_dirty: invalid taint tag %u\n", tag );
+        return DIFT_ERR_INVALIDTAG;
     }
 
-    dc->mem_dirty_tbl[addr] &= contamination;
+    while( len ) {
+        dc->mem_dirty_tbl[addr] = (is_append)? dc->mem_dirty_tbl[addr] | tag : tag;
+        ++addr;
+        --len;
+    }
+
+    return DIFT_SUCCESS;
 }
 
+static inline DIFT_STATUS and_mem_dirty( dift_context* dc, uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag ) {
+
+    if( !is_valid_mem_range(addr, len) ) {
+        dift_log( "and_mem_dirty: out of range, addr=%16lx, len=%16lx\n", addr, len );
+        return DIFT_ERR_OUTOFRANGE;
+    }
+
+    if( !is_valid_tag(tag) ) {
+        dift_log( "and_mem_dirty: invalid taint tag %u\n", tag );
+        return DIFT_ERR_INVALIDTAG;
+    }
+
+    while( len ) {
+        dc->mem_dirty_tbl[addr] &= tag;
+        ++addr;
+        --len;
+    }
+
+    return DIFT_SUCCESS;
+}
 
 static inline CONTAMINATION_RECORD get_mem_dirty( dift_context* dc, uint64_t addr ) { 
+
     if( !is_valid_mem_range(addr, 1) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "get_mem_dirty: invalid address" );
-#endif
+        dift_log( "get_mem_dirty: out of range, addr=%16lx\n", addr );
         return 0;
     }
     return dc->mem_dirty_tbl[addr];
@@ -840,44 +873,62 @@ static CONTAMINATION_RECORD* _MOCKABLE(alloc_hd_dirty_page)( void ) {
     return rec;
 }
 
-static int _MOCKABLE(is_valid_disk_range)( uint64_t haddr, uint64_t len ) {
+static DIFT_STATUS set_hd_dirty_or( dift_context* dc, uint64_t hdaddr, uint64_t len, CONTAMINATION_RECORD tag ) {
 
-    if( HD_MAX_SIZE < haddr || HD_MAX_SIZE - haddr < len )
-        return false;
-    return true;
-}
-
-static void set_hd_dirty_or( dift_context* dc, uint64_t hdaddr, CONTAMINATION_RECORD contamination ) {
-
-    if( !is_valid_disk_range(hdaddr, 1) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "set_hd_dirty_or: invalid address" );
-#endif
-        return;
+    if( !is_valid_disk_range(hdaddr, len) ) {
+        dift_log( "set_hd_dirty_or: out of range, addr=%16lx, len=%16lx\n", hdaddr, len);
+        return DIFT_ERR_OUTOFRANGE;
     }
 
-    if( contamination == 0 )
-        return;
-
-    if( dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)] == NULL ) 
-        dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)] = alloc_hd_dirty_page();
-
-    dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)][HD_L2_INDEX(hdaddr)] |= contamination;
-}
-
-static void set_hd_dirty_and( dift_context* dc, uint64_t hdaddr, CONTAMINATION_RECORD contamination ) {
-
-    if( !is_valid_disk_range(hdaddr, 1) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "set_hd_dirty_and: invalid address" );
-#endif
-        return;
+    if( !is_valid_tag(tag) ) {
+        dift_log( "set_hd_dirty_or: invalid taint tag %u\n", tag );
+        return DIFT_ERR_INVALIDTAG;
     }
 
-    if( dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)] == NULL ) 
-        return;
+    // no taint required, return immediately
+    if( tag == 0 )
+        return DIFT_SUCCESS;
 
-    dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)][HD_L2_INDEX(hdaddr)] &= contamination;
+    // XXX: the loop can still be optimized by removing duplicated operation
+    while( len ) {
+        if( dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)] == NULL ) 
+            dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)] = alloc_hd_dirty_page();
+
+        dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)][HD_L2_INDEX(hdaddr)] |= tag;
+
+        ++hdaddr;
+        --len;
+    }
+
+    return DIFT_SUCCESS;
+}
+
+static DIFT_STATUS set_hd_dirty_and( dift_context* dc, uint64_t hdaddr, uint64_t len, CONTAMINATION_RECORD tag ) {
+
+    if( !is_valid_disk_range(hdaddr, len) ) {
+        dift_log( "set_hd_dirty_and: out of range, addr=%16lx, len=%16lx\n", hdaddr, len);
+        return DIFT_ERR_OUTOFRANGE;
+    }
+
+    if( !is_valid_tag(tag) ) {
+        dift_log( "set_hd_dirty_and: invalid taint tag %u\n", tag );
+        return DIFT_ERR_INVALIDTAG;
+    }
+
+    // no taint required, return immediately
+    if( tag == 0 )
+        return DIFT_SUCCESS;
+
+    // XXX: the loop can still be optimized by removing duplicated operation
+    while( len ) {
+        if( dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)] != NULL ) 
+            dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)][HD_L2_INDEX(hdaddr)] &= tag;
+
+        ++hdaddr;
+        --len;
+    }
+    
+    return DIFT_SUCCESS;
 }
 
 static CONTAMINATION_RECORD get_hd_dirty( dift_context* dc, uint64_t hdaddr ) {
@@ -885,14 +936,13 @@ static CONTAMINATION_RECORD get_hd_dirty( dift_context* dc, uint64_t hdaddr ) {
     CONTAMINATION_RECORD* hd_l2_dirty_tbl = NULL;
 
     if( !is_valid_disk_range(hdaddr, 1) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "get_hd_dirty: invalid address" );
-#endif
+        dift_log( "get_hd_dirty: out of range, addr=%16lx\n", hdaddr );
         return 0;
     }
 
     if( (hd_l2_dirty_tbl = dc->hd_l1_dirty_tbl[HD_L1_INDEX(hdaddr)]) == NULL )
         return 0;
+
     return hd_l2_dirty_tbl[HD_L2_INDEX(hdaddr)];
 }
 
@@ -903,9 +953,7 @@ static void copy_contamination_hd_mem( dift_context* dc, uint64_t hdaddr, uint64
 
     if( !is_valid_mem_range(ra, len)
         || !is_valid_disk_range(hdaddr, len) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "copy_contamination_hd_mem: invalid range" );
-#endif
+        dift_log( "copy_contamination_hd_mem: out of range, hdaddr=%16lx, raddr=%16lx, len=%16lx\n", hdaddr, ra, len );
         return;
     }
 
@@ -934,11 +982,10 @@ static void copy_contamination_mem_hd( dift_context* dc, uint64_t wa, uint64_t h
     
     uint64_t progress = ((hdaddr + (1 << HD_L2_INDEX_BITS)) & HD_L2_INDEX_MASK) - hdaddr;
 
-    if( !is_valid_mem_range(wa, len)
-        || !is_valid_disk_range(hdaddr, len) ) {
-#if defined(CONFIG_DIFT_DEBUG)
-        dift_log( "copy_contamination_mem_hd: invalid range" );
-#endif
+    if(
+        !is_valid_mem_range(wa, len)
+    ||  !is_valid_disk_range(hdaddr, len) ) {
+        dift_log( "copy_contamination_mem_hd: out of range, waddr=%16lx, hdaddr=%16lx, len=%16lx\n", wa, hdaddr, len );
         return;
     }
 
@@ -1079,17 +1126,6 @@ static void* analysis_mainloop( void* arg ) {
     return NULL;
 }
 
-// DIFT Private API - taint operand validity check
-static int _MOCKABLE(is_valid_tag)( const CONTAMINATION_RECORD tag ) {
-
-    CONTAMINATION_RECORD mask = 0x7f;
-
-    // DIFT support only the 7 least significant bits as the taint tag
-    if( (tag & (~mask)) != 0 )
-        return false;
-    return true;
-}
-
 // DIFT Public API - All of the public APIs are named with the prefix "dift_"
 int _MOCKABLE(dift_log)( const char* fmt, ... ) {
     int ret = -1;
@@ -1131,7 +1167,7 @@ void _MOCKABLE(dift_rec_enqueue)( uint64_t data_in ) {
 uint8_t dift_rec_case_nb( uint8_t dst_type, uint8_t src_type, uint8_t ot, uint8_t effect ) {
 
     uint8_t ret = case_mapping[((0xc0 | src_type << 4 | dst_type << 2 | ot) << 8) | effect];
-    if( ret == 0xff ) { 
+    if( ret == 0xff ) {
         dift_log( "No matching DIFT record case: \n" );
         dift_log( "dst_type : %d, src_type : %d, ot : %d, effect : %d\n", dst_type, src_type, ot, effect );
         exit( 1 );
@@ -1161,7 +1197,7 @@ void dift_sync( void ) {
     dift_thread_ok_signal = 0;
 }
 
-int dift_start( void ) {
+DIFT_STATUS dift_start( void ) {
     
     int err;
     
@@ -1181,117 +1217,32 @@ int dift_start( void ) {
         dift_log( "Fail to startup DIFT analysis thread\n" );
         return DIFT_ERR_FAIL;
     }
-    return DIFT_SUCCESS;
-}
-
-int dift_contaminate_memory_or( uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag ) {
-
-    dift_record rec = DIFT_REC_EMPTY;
-
-    uint64_t len_pt,
-             len_pt_max = 0xffffffff; 
-    
-    if( !is_valid_tag(tag) )
-        return DIFT_ERR_INVALIDTAG;
-
-    if( !is_valid_mem_range(addr, len) )
-        return DIFT_ERR_OUTOFRANGE;
-
-    rec.case_nb = REC_CONTAMINATE_MEM_OR;
-    while( len > 0 ) {
-        
-        len_pt = (len > len_pt_max)? len_pt_max : len;
-        
-        *((uint64_t*)&rec) |= ((0x00000000000000ff & tag)    << 8);
-        *((uint64_t*)&rec) |= ((0x00000000ffffffff & len_pt) << 16);
-
-        dift_rec_enqueue( *((uint64_t*)&rec) );
-        dift_rec_enqueue( addr );
-
-        addr += len_pt;
-        len  -= len_pt;
-    }
 
     return DIFT_SUCCESS;
 }
 
-int dift_contaminate_memory_and( uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag ) {
-    
-    dift_record rec = DIFT_REC_EMPTY;
-
-    uint64_t len_pt,
-             len_pt_max = 0xffffffff; 
-
-    if( !is_valid_tag(tag) )
-        return DIFT_ERR_INVALIDTAG;
-
-    if( !is_valid_mem_range(addr, len) )
-        return DIFT_ERR_OUTOFRANGE;
-
-    rec.case_nb = REC_CONTAMINATE_MEM_AND;
-    while( len > 0 ) {
-        
-        len_pt = (len > len_pt_max)? len_pt_max : len;
-        
-        *((uint64_t*)&rec) |= ((0x00000000000000ff & tag)    << 8);
-        *((uint64_t*)&rec) |= ((0x00000000ffffffff & len_pt) << 16);
-
-        dift_rec_enqueue( *((uint64_t*)&rec) );
-        dift_rec_enqueue( addr );
-
-        addr += len_pt;
-        len  -= len_pt;
-    }
-
-    return DIFT_SUCCESS;
+DIFT_STATUS dift_contaminate_memory_or( uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag ) {
+    return set_mem_dirty( dc, addr, len, tag, 1 );
 }
 
-int dift_contaminate_disk_or( uint64_t haddr, uint64_t len, CONTAMINATION_RECORD tag ) {
-
-    dift_record rec = DIFT_REC_EMPTY;
-
-    if( !is_valid_tag(tag) )
-        return DIFT_ERR_INVALIDTAG;
-
-    if( !is_valid_disk_range(haddr, len) )
-        return DIFT_ERR_OUTOFRANGE;
-
-    rec.case_nb = REC_CONTAMINATE_HD_OR;
-    *((uint64_t*)&rec) |= ((0x00000000000000ff &tag) << 8);
-
-    dift_rec_enqueue( *((uint64_t*)&rec) );
-    dift_rec_enqueue( haddr );
-    dift_rec_enqueue( len ); 
-
-    return DIFT_SUCCESS;
+DIFT_STATUS dift_contaminate_memory_and( uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag ) {
+    return and_mem_dirty( dc, addr, len, tag );
 }
 
-int dift_contaminate_disk_and( uint64_t haddr, uint64_t len, CONTAMINATION_RECORD tag ) {
+DIFT_STATUS dift_contaminate_disk_or( uint64_t hdaddr, uint64_t len, CONTAMINATION_RECORD tag ) {
+    return set_hd_dirty_or( dc, hdaddr, len, tag );
+}
 
-    dift_record rec = DIFT_REC_EMPTY;
-
-    if( !is_valid_tag(tag) )
-        return DIFT_ERR_INVALIDTAG;
-
-    if( !is_valid_disk_range(haddr, len) )
-        return DIFT_ERR_OUTOFRANGE;
-
-    rec.case_nb = REC_CONTAMINATE_HD_AND;
-    *((uint64_t*)&rec) |= ((0x00000000000000ff &tag) << 8);
-
-    dift_rec_enqueue( *((uint64_t*)&rec) );
-    dift_rec_enqueue( haddr );
-    dift_rec_enqueue( len ); 
-
-    return DIFT_SUCCESS;
+DIFT_STATUS dift_contaminate_disk_and( uint64_t hdaddr, uint64_t len, CONTAMINATION_RECORD tag ) {
+    return set_hd_dirty_and( dc, hdaddr, len, tag );
 }
 
 CONTAMINATION_RECORD dift_get_memory_dirty( uint64_t addr ) {
     return get_mem_dirty( dc, addr );
 }
 
-CONTAMINATION_RECORD dift_get_disk_dirty( uint64_t haddr ) {
-    return get_hd_dirty( dc, haddr );
+CONTAMINATION_RECORD dift_get_disk_dirty( uint64_t hdaddr ) {
+    return get_hd_dirty( dc, hdaddr );
 }
 
 void dift_enable( void ) {

--- a/ext/dift/dift.h
+++ b/ext/dift/dift.h
@@ -143,12 +143,14 @@
 #define CONTAMINATION_RECORD uint8_t
 
 // Return Code of Public API
-enum DIFT_RETURN_CODE {
+enum DIFT_STATUS {
     DIFT_SUCCESS,
     DIFT_ERR_OUTOFRANGE,
     DIFT_ERR_INVALIDTAG,
-    DIFT_ERR_FAIL,
+    DIFT_ERR_FAIL
 };
+typedef enum DIFT_STATUS DIFT_STATUS;
+
 
 ///
 /// We use 2-layer page table to record the harddisk taint status
@@ -367,7 +369,7 @@ struct dift_context {
 
 /// 
 /// The following variables are declared as global variables for DIFT implementation
-/// It is STRONGLY recommanded that you should AVOID accessing them directly.
+/// It is STRONGLY NOT recommanded to access them directly.
 /// Instead, DIFT-related features should be used via the exported "dift_xxx" APIs
 ///
 typedef struct dift_context dift_context;
@@ -413,6 +415,8 @@ extern uint8_t* rt_enqueue_one_rec;
 extern uint8_t* rt_enqueue_raddr;
 extern uint8_t* rt_enqueue_waddr;
 
+extern dift_context dc[];
+
 /// Inform dift system and then block(spinning) until
 /// dift system declares to accept more IFcodes.
 /// Current Called before translating every code blocks.
@@ -429,14 +433,13 @@ extern void dift_sync(void);
 extern FILE* dift_logfile;
 extern int   dift_log( const char*, ... );
 
-
 /// Initializes dift function.
 /// Currently called in pc_init1() (in Pc_piix.c)
 /// 
 /// No parameter
 /// 
-/// Returns 1 if create dift thread successfully,0 otherwise.
-extern int dift_start(void);
+/// Returns DIFT_SUCCESS on success, DIFT_ERR_FAIL otherwise
+extern DIFT_STATUS dift_start(void);
 
 /// Pushes a "struct dift_record", or additional information(like addr) into the queue.
 /// 
@@ -476,7 +479,7 @@ extern bool dift_is_enabled(void);
 /// \param ot		operand type(8,16,32,etc)
 /// \param effect   effect type
 ///
-/// No return value
+/// Return DIFT record case number
 extern uint8_t dift_rec_case_nb(uint8_t dst_type, uint8_t src_type, uint8_t ot, uint8_t effect);
 
 /// Set the contaminate record to the result of or operation with tag.
@@ -485,8 +488,8 @@ extern uint8_t dift_rec_case_nb(uint8_t dst_type, uint8_t src_type, uint8_t ot, 
 /// \param len      The length(in bytes) to be set
 /// \param tag      The contaminate value
 /// 
-/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
-extern int dift_contaminate_memory_or(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
+/// Return DIFT_STATUS code
+extern DIFT_STATUS dift_contaminate_memory_or(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
 
 /// Set the contaminate record to the result of and operation with tag.
 /// 
@@ -494,8 +497,8 @@ extern int dift_contaminate_memory_or(uint64_t addr, uint64_t len, CONTAMINATION
 /// \param len      The length(in bytes) to be set
 /// \param tag      The contaminate value
 /// 
-/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
-extern int dift_contaminate_memory_and(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
+/// Return DIFT_STATUS code
+extern DIFT_STATUS dift_contaminate_memory_and(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
 
 /// Set the contaminate record to the result of or operation with tag.
 /// 
@@ -503,8 +506,8 @@ extern int dift_contaminate_memory_and(uint64_t addr, uint64_t len, CONTAMINATIO
 /// \param len      The length(in bytes) to be set
 /// \param tag      The contaminate value
 /// 
-/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
-extern int dift_contaminate_disk_or(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
+/// Return DIFT_STATUS code
+extern DIFT_STATUS dift_contaminate_disk_or(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
 
 /// Set the contaminate record to the result of and operation with tag.
 /// 
@@ -512,15 +515,15 @@ extern int dift_contaminate_disk_or(uint64_t addr, uint64_t len, CONTAMINATION_R
 /// \param len      The length(in bytes) to be set
 /// \param tag      The contaminate value
 /// 
-/// Returns DIFT_SUCCESS while success, DIFT_ERR_FAIL otherwise.
-extern int dift_contaminate_disk_and(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
+/// Return DIFT_STATUS code
+extern DIFT_STATUS dift_contaminate_disk_and(uint64_t addr, uint64_t len, CONTAMINATION_RECORD tag);
 
 /// Get the contamination status of a phsical memory byte.
 /// The most significant bit is used for marking whether a code block contains tainted code.
 /// 
 /// \param offset   The address of the byte in memory to be checked
 /// 
-/// Returns CONTAMINATION_RECORD type.
+/// Return taint tag
 extern CONTAMINATION_RECORD dift_get_memory_dirty(uint64_t offset);
 
 /// Get the contamination status of a disk byte.
@@ -528,21 +531,8 @@ extern CONTAMINATION_RECORD dift_get_memory_dirty(uint64_t offset);
 /// 
 /// \param hdaddr   The address of the byte in disk to be checked
 /// 
-/// Returns CONTAMINATION_RECORD type.
+/// Return taint tag
 extern CONTAMINATION_RECORD dift_get_disk_dirty(uint64_t hdaddr);
 
-/// Flush the record queue if needed.
-///
-/// \param cnt   Number of sets of records that have already been enqueued. Each set of records
-///              may be enqueued by several enqueue() call.
-/// FIXME(misterlihao): Definition not found.
-void record_queue_flush(size_t cnt);
-
-/// FIXME(misterlihao): Definition not found.
-extern void clear_memory(uint64_t, uint64_t);
-
-
-// DIFT context
-extern dift_context dc[];
 #endif
 


### PR DESCRIPTION
The DIFT status is now updated instantly after enable/disable operation.
The use of DIFT queue for taint record is removed from the implementation of public APIs.
Thus, the race condition between other thread and the QMEU main thread can be avoided.